### PR TITLE
Rename as prop to "component"

### DIFF
--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -35,7 +35,7 @@ const BlogPage = ({ posts }: BlogPageProps) => {
   return (
     <Layout>
       <Box
-        as="section"
+        component="section"
         padding="gutter"
         paddingTop="xxl"
         css={{ maxWidth: textMaxWidth, margin: '0 auto' }}
@@ -46,7 +46,7 @@ const BlogPage = ({ posts }: BlogPageProps) => {
           </h1>
         </Heading>
 
-        <Box as="ul" paddingBottom="m">
+        <Box component="ul" paddingBottom="m">
           {posts.map(post => (
             <li key={post.href}>
               <PostListItem

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -55,6 +55,8 @@ interface PostPageProps {
 
 /**
  * This page displays an individual post for viewing.
+ *
+ * The mdx in the
  */
 const PostPage: NextPage<PostPageProps> = props => {
   // Hydrate the MDX content. The second argument is an object of React components
@@ -113,7 +115,7 @@ const PostPage: NextPage<PostPageProps> = props => {
       </Head>
 
       <Box
-        as="main"
+        component="main"
         padding="gutter"
         paddingY="xxl"
         css={{

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,7 +65,7 @@ const IndexPage = () => (
       </p>
 
       <Box
-        as="ul"
+        component="ul"
         display="flex"
         paddingY="xl"
         css={{
@@ -74,7 +74,7 @@ const IndexPage = () => (
       >
         {navigation.map((link, i) => (
           <Box
-            as="li"
+            component="li"
             key={link.href}
             paddingY="xs"
             paddingLeft={i === 0 ? 'none' : 'xxl'}

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -13,7 +13,7 @@ interface BoxProps {
   /** Contents of the box */
   children?: ReactNode
   /** Allows customization of the rendered HTML under the hood */
-  as?: keyof HTMLElementTagNameMap
+  component?: keyof HTMLElementTagNameMap
   /**
    * Allows overriding the applied CSS. This should be a last resort over using
    * the built-in styling props
@@ -92,10 +92,10 @@ export const Box = ({
   paddingBottom,
   className,
   display,
-  as = 'div',
+  component = 'div',
   ...props
 }: BoxProps) => {
-  return jsx(as, {
+  return jsx(component, {
     ...props,
     className,
     css: [

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,10 +1,10 @@
-import { jsx, Interpolation } from '@emotion/core'
-import { ReactNode, CSSProperties } from 'react'
-import { SpacingToken, spacing } from '../styles/theme'
+import { jsx } from '@emotion/core'
+import { CSSProperties, ReactNode } from 'react'
 import {
-  ResponsiveProp,
   resolveResponsiveValue,
+  ResponsiveProp,
 } from '../styles/resolveResponsiveValue'
+import { spacing, SpacingToken } from '../styles/theme'
 /** @jsx jsx */ jsx
 
 type BoxPaddingToken = SpacingToken | 'none'


### PR DESCRIPTION
This is a little clearer and this way it doesn't clash with `<Link as={route} />`