### PR TITLE
Fix bug in mocking fetch article

### DIFF
--- a/cypress/integration/post.spec.ts
+++ b/cypress/integration/post.spec.ts
@@ -36,7 +36,7 @@ describe('Post page', () => {
 
     cy.contains(pageContent.title).should('exist')
     cy.get('[data-testid="SlugPage__footer"')
-      .contains('2019-04-26')
+      .contains('2020-12-30')
       .should('exist')
     cy.get('[data-testid="SlugPage__footer"')
       .contains('Last updated')

--- a/lib/getPostBySlug.test.ts
+++ b/lib/getPostBySlug.test.ts
@@ -9,6 +9,7 @@ test('should return parsed post data for a given slug', () => {
       "Why should we mock the network? We'll take a look at why it's important to mock window.fetch and a couple methods we can use in our test suites.",
     draft: false,
     date: new Date('2019-04-26T00:00:00.000Z'),
+    lastUpdated: new Date('2020-12-30T00:00:00.000Z'),
     image: {
       url: 'blue-paint-swirls.jpg',
       alt: 'Abstract swirling colors of blue and red',


### PR DESCRIPTION
Someone kindly pointed out a bug in the mock—`json` method itself returns a `Promise`, so the mock itself needs to return a `Promise`