### PR TITLE
refactor(svelte): homepage + markdown renderer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"editor.defaultFormatter": "biomejs.biome",
 	"[typescript]": {
-		"editor.defaultFormatter": "biomejs.biome"
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
 	"[typescriptreact]": {
 		"editor.defaultFormatter": "biomejs.biome"

--- a/apps/website-sv/package.json
+++ b/apps/website-sv/package.json
@@ -32,8 +32,24 @@
 		"vitest-browser-svelte": "^2.1.0"
 	},
 	"dependencies": {
+		"@benjamminj/content": "workspace:*",
 		"@fontsource-variable/jetbrains-mono": "^5.2.8",
+		"@types/hast": "^3.0.4",
+		"@types/mdast": "^4.0.4",
 		"clsx": "^2.1.1",
-		"tailwind-merge": "^1.14.0"
+		"front-matter": "^4.0.2",
+		"glob": "^11.1.0",
+		"hast": "^1.0.0",
+		"rehype-parse": "^9.0.1",
+		"rehype-pretty-code": "^0.14.1",
+		"rehype-stringify": "^10.0.1",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-rehype": "^11.1.2",
+		"shiki": "^3.19.0",
+		"tailwind-merge": "^1.14.0",
+		"unified": "^11.0.5",
+		"unist-util-visit": "^5.0.0",
+		"zod": "^3.25.76"
 	}
 }

--- a/apps/website-sv/package.json
+++ b/apps/website-sv/package.json
@@ -40,6 +40,7 @@
 		"front-matter": "^4.0.2",
 		"glob": "^11.1.0",
 		"hast": "^1.0.0",
+		"hast-util-from-html": "^2.0.3",
 		"rehype-parse": "^9.0.1",
 		"rehype-pretty-code": "^0.14.1",
 		"rehype-stringify": "^10.0.1",
@@ -49,6 +50,7 @@
 		"shiki": "^3.19.0",
 		"tailwind-merge": "^1.14.0",
 		"unified": "^11.0.5",
+		"unist-util-filter": "^5.0.1",
 		"unist-util-visit": "^5.0.0",
 		"zod": "^3.25.76"
 	}

--- a/apps/website-sv/src/app.d.ts
+++ b/apps/website-sv/src/app.d.ts
@@ -9,5 +9,12 @@ declare global {
 		// interface Platform {}
 	}
 }
+declare module '*.md' {
+	import type { SvelteComponent } from 'svelte'
+
+	export default class Comp extends SvelteComponent{}
+
+	export const metadata: Record<string, unknown>
+}
 
 export {};

--- a/apps/website-sv/src/content/about.md
+++ b/apps/website-sv/src/content/about.md
@@ -1,0 +1,7 @@
+Thanks for popping into my little corner of the internet.
+
+I build large scale frontend web applications, specifically with an eye towards progressive enhancement, accessibility, and simplicity. I currently work as a software engineer at [Sublime Security](https://sublimesecurity.com/).
+
+I'm currently based out of the greater Seattle area where my family and I love the wet winters and beautiful PNW summers.
+
+Wanna connect? Reach out on [Bluesky](/links/bluesky) or shoot me an [email](/links/email), I'd love to hear from you.

--- a/apps/website-sv/src/content/clippings.json
+++ b/apps/website-sv/src/content/clippings.json
@@ -1,0 +1,62 @@
+[
+	{
+		"name": "The Wrong Abstraction",
+		"url": "https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction",
+		"tags": ["software-engineering"]
+	},
+	{
+		"name": "A Codebase is an Organism",
+		"url": "https://meltingasphalt.com/a-codebase-is-an-organism",
+		"tags": ["software-engineering", "tech-debt", "philosophy"]
+	},
+	{
+		"name": "On the Spectrum of Abstraction (YouTube)",
+		"url": "https://www.youtube.com/watch?v=mVVNJKv9esE",
+		"tags": ["software-engineering", "philosophy"]
+	},
+	{
+		"name": "The Canvas Cares Not",
+		"url": "https://www.neversaw.us/2022/01/30/the-canvas-cares-not",
+		"tags": ["software-engineering", "philosophy"]
+	},
+	{
+		"name": "On Being A Senior Engineer",
+		"url": "https://www.kitchensoap.com/2012/10/25/on-being-a-senior-engineer/",
+		"tags": ["software-engineering", "career"]
+	},
+	{
+		"name": "Parse, don't validate",
+		"url": "https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/",
+		"tags": ["software-engineering"]
+	},
+	{
+		"name": "Small CLs",
+		"url": "https://google.github.io/eng-practices/review/developer/small-cls.html",
+		"tags": ["software-engineering", "teamwork", "pull-requests"]
+	},
+	{
+		"name": "How Complex Systems Fail",
+		"url": "https://how.complexsystems.fail/",
+		"tags": ["software-engineering", "philosophy"]
+	},
+	{
+		"name": "Being Glue",
+		"url": "https://noidea.dog/glue",
+		"tags": ["software-engineering", "career", "teamwork"]
+	},
+	{
+		"name": "Customization vs. Configuration in Evolving Design Systems",
+		"url": "https://engineering.atspotify.com/2021/04/customization-vs-configuration-in-evolving-design-systems/",
+		"tags": ["software-engineering", "philosophy", "tech-debt"]
+	},
+	{
+		"name": "Write code that is easy to delete, not easy to extend.",
+		"url": "https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to",
+		"tags": ["software-engineering", "philosophy", "tech-debt"]
+	},
+	{
+		"name": "Repeat yourself, do more than one thing, and rewrite everything",
+		"url": "https://programmingisterrible.com/post/176657481103/repeat-yourself-do-more-than-one-thing-and",
+		"tags": ["software-engineering", "philosophy", "tech-debt"]
+	}
+]

--- a/apps/website-sv/src/content/drafts/add-less-working-title.md
+++ b/apps/website-sv/src/content/drafts/add-less-working-title.md
@@ -1,0 +1,17 @@
+---
+title: Thoughts on "Add Less"
+date: 2023-10-15
+tags:
+  - software
+  - architecture
+---
+
+Raw notes:
+
+- "websites start fast until you add things to make them slow" (Cassidy Williams)
+- the challenge is knowing when you need to do less and when you actually need "more"
+  - it's easy to be idealistic or dogmatic about how we build things without taking the
+    full context into account:
+    - what timeline are you working on, and is it a "hard" or "soft" timeline?
+    - will adding "more" help the bottom line? (aka the business needs customers)
+    - will you need "more" in the near- or far-term future?

--- a/apps/website-sv/src/content/drafts/csrf-cheat-sheet.md
+++ b/apps/website-sv/src/content/drafts/csrf-cheat-sheet.md
@@ -1,0 +1,20 @@
+---
+title: CSRF (Cheat Sheet)
+date: 2022-02-21
+tags:
+  - security
+  - http
+---
+
+- What is CSRF?
+  - CSRF stands for Cross Site Request Forgery
+  - This type of attack uses the cookies in a user's browser to make requests to an authenticated site that the user didn't intend to make.
+- Example / Diagram
+
+  - User is currently logged into site (for example their bank)
+  - The target site stores a _cookie_ in the user's browser to track authentication state. Whenever the user visits the target site and performs actions (for example, a money transfer), the browser sends that cookie along with the HTTP request. The _server_ then uses that cookie to determine that the user is authenticated.
+
+- How to protect against CSRF
+  - CSRF token (best)
+  - Same-Site cookies
+  - Disable CORS

--- a/apps/website-sv/src/content/drafts/design-system-color-tokens.md
+++ b/apps/website-sv/src/content/drafts/design-system-color-tokens.md
@@ -1,0 +1,31 @@
+---
+title: design system color tokens
+date: 2022-03-27
+tags:
+  - design-systems
+  - css
+---
+
+- common issues with design tokens
+  - going too abstract too soon
+  - tokens are _too_ constrained
+  - no guidance on how to use tokens
+  - thinking that components = tokens
+  - naming things too specific, or not clearly.
+- my working list of color system tokens
+  - `$base` - the base "canvas" of the application.
+  - `$base-muted` - this is from the same palette as `$base`, but used to de-emphasize an element's background. Depending on the theme, that could be lighter _or_ darker.
+  - `$base-strong` - this is from the same palette as `$base`, but used to emphasis an element's background. Depending on the theme, that could be lighter _or_ darker.
+  - `$contrast` - this is for content that's on top of `$base`. It should meet at least AA, ideally AAA contrast ratio.
+  - `$contrast-muted` - this is from the same palette as `$contrast` but is used to de-emphasize content. It should meet at least AA contrast ratio.
+  - `$contrast-strong` - this is from the same palette as `$contrast` but is used to emphasize content. It should meet at least AA contrast ratio.
+- system ideas
+  - per token, the following variants:
+    - `-muted`
+    - `-strong`
+    - `-contrast`
+    - `-contrast-muted`
+    - `-contrast-strong`
+  - per variant, the following interactive states:
+    - `-hover`
+    - `-active`

--- a/apps/website-sv/src/content/drafts/engineering-challenges-spent-too-much-time-with.md
+++ b/apps/website-sv/src/content/drafts/engineering-challenges-spent-too-much-time-with.md
@@ -1,0 +1,30 @@
+---
+title: Engineering challenges I've spent too much time with
+date: 2022-06-02
+tags:
+  - software-engineering
+---
+
+Over the last 10 years of my career there's certain engineering problems that I keep experiencing. Some are very very complex or seem simple on the surface with a giant iceberg of complexity underneath.
+
+I'm not trying to unpack all those problems here. Just going to keep a list of some of the ones I remember, along with a short summary of why that problem is a giant pain. The hope is that I can write some longer form articles about each one and why it's nasty as time goes on.
+
+## Filters
+
+Aka faceted search. Filters seem simple until you peek behind the curtain. Then you see a mess of complexity and tradeoffs. To make matters worse, nearly every app has them in varying levels of quality.
+
+There's too much to go into here, but at a high level:
+- State management in the frontend gets tricky, especially if you don't use the URL as the source of truth. Depending on the implementation + API latency, using the URL has its own challenges (avoiding page refreshes, input lag, etc).
+- The differences + relationships between "selections", "options", and a "facet/filter" (a group of selections + options) will undoubtedly trip you up at some point.
+- Efficiently aggregating results data into options can be a non-trivial database problem once you hit even a moderate scale. It also doesn't matter how many UI bells and whistles you have if the API serving results is slow.
+- Showing counts next to options is a standard UX for filters, but you have to decide when to refresh options + counts in response to selections. Every selection refreshes _something_: the challenge is figuring out what refreshes and how to keep the refresh logic sane.
+- You also have a number of challenging UX + UI problems: deciding how to display filters, responsiveness (especially if the filters are not in a drawer), virtualization, pagination-vs-infinite-scroll, refetching, caching, URL persistence, etc. Any one of these _individually_ is ~easy, putting them all together is what gets tricky.
+
+When it comes to filters, I have written short novellas about this at the last 3 companies I worked at. I've had the (mis-)fortune to build faceted search like 7-8 times in my career over 4-5 different roles. I'm hoping to write something more long-form here about them in the future to capture a more detailed view of all the problems I've seen.
+
+## Data tables
+
+## Forms
+
+## Server side rendering (SSR)
+

--- a/apps/website-sv/src/content/drafts/infinite-scroll-and-accessibility.md
+++ b/apps/website-sv/src/content/drafts/infinite-scroll-and-accessibility.md
@@ -1,0 +1,31 @@
+---
+title: Infinite scroll and accessibility
+date: 2022-02-03
+tags:
+  - accessibility
+  - html
+  -
+---
+
+## Outline
+
+- if you do infinite scroll, you better do it right for those using assistive tech
+
+  - if a feature only works for a portion of your users, it doesn't really work.
+
+- if you give a mouse a cookie...
+
+  - if you have enough data to require an infinite scroll, you probably should be
+    _windowing_ the data.
+  - windowing is really hard to do accessibly.
+
+- infinite scrolling + windowing aren't even necessarily a good UX at all.
+
+  - lose your place, oh whale.
+  - users maintain a mental model of where things are with pagination.
+  - infinite scrolling is good for data that actually is...infinite.
+
+- if accessibility is the goal, infinite scrolling is probably not the best choice.
+  - breaks the footer
+  - makes it impossible to jump to the "end" of the page
+  - harder for screen reader users to quickly find page content (especially content that hasn't been loaded yet!)

--- a/apps/website-sv/src/content/drafts/myths-about-comments.md
+++ b/apps/website-sv/src/content/drafts/myths-about-comments.md
@@ -1,0 +1,61 @@
+---
+title: debunking arguments against code comments
+tags:
+  - code-comments
+---
+
+Every month or two I end up seeing a post on LinkedIn or Twitter condemning code comments as "bad programming". And sometimes I just shrug it off and move on with my day.
+
+However, there's a lot of us out there that like code comments! They're a valuable tool for us to show empathy for our teammates that will maintain the code we write.
+
+A lot of arguments against comments come straight out of Clean Code, but these are the ones I've heard—both IRL and on the internet. As someone who likes comments, I think there's valid ways to address each of these arguments head-on.
+
+## "Don't write comments, put it in a variable instead"
+
+Ummm...I don't want to read variable names a mile long in camelCase. That makes my eyes bleed and my brain explode.
+
+Instead, we have a language construct for expressing complex and nuanced thoughts—sentences.
+
+Sure, redundant comments exist, and you should absolutely use good variables names. But variables aren't mutually exclusive with code comments.
+
+<!-- TODO: don't actually include the quote -->
+
+<!--
+> I don't remember the last time I wrote a comment in my code
+>
+> Most of the time we can get rid of comments by just extracting a method and providing a meaningful name.
+>
+> In programming, clarity and expressiveness are everything.
+>
+> As you can see in the image below, comments usually just add noise.
+-->
+
+## "Comments get out of date, code is the only source of truth"
+
+Comments don't get run by your runtime / compiler, so it's possible that they're misleading, out-of-date, or downright wrong.
+
+But I'll let you in on a little secret: it's not unique to comments. For example, variables and function names. Your runtime doesn't care if you name a variable `user.firstName` or `user.potato`.
+
+Codebases require maintenance, and comments are a part of the codebase. It's on you and your team to commit to maintaining them!
+
+## "Don't write comments, capture context in commit messages instead"
+
+First off, this only works if everyone on your team is diligent about their commit messages. In my career, I think I've worked in _one_ place where this was true.
+
+Second, commits have a higher impedance than code comments. You don't have to seek out comments, they're gonna be right next to the code they describe. You'll have to seek out the relevant commit after thinking to yourself "this code doesn't have all the context". If it's a long-lived codebase this could mean sifting through years of commits.
+
+Comments let you warn future maintainers, without forcing them to go find the relevant information themselves.
+
+## "Comments add too much noise, and code should be beautiful"
+
+The first part of this sentence is personal preference. And I'd argue that the second part isn't necessarily true—it all depends on how you view code.
+
+Some view code as something that should be a work of art on its own. And they're allowed to believe that.
+
+But for some of us (myself included) code is a means to an end. Making the code _beautiful_ is not the goal. Hence the phrase, ["make it work, make it right, make it fast"](https://wiki.c2.com/?MakeItWorkMakeItRightMakeItFast).
+
+Often "making it right" means swallowing our pride and using a comment because that's the clearest way to communicate why the code was written. The code that gets the job done won't always be crystal-clear to others (or future you)!
+
+---
+
+There's a whole host of arguments in _favor_ of writing comments, stay tuned for a future post!

--- a/apps/website-sv/src/content/drafts/react-fc-vs-function-params.md
+++ b/apps/website-sv/src/content/drafts/react-fc-vs-function-params.md
@@ -1,0 +1,114 @@
+---
+title: React.FC vs TypeScript function parameters
+date: 2022-02-03
+tags:
+  - typescript
+  - react
+  - formatting
+---
+
+My strong preference is to use regular TS function parameters to type React components, rather than the `React.FC` (or its longer alias, `React.FunctionComponent`) that comes packaged with `React`.
+
+At the end of the day, this is _mostly_ stylistic preference, but _even personal preferences have reasons behind them_. Those preferences may not be enough to quit a job or label a codebase as "terrible", but there's still benefits/tradeoffs to be considered.
+
+Here's a few reasons why I prefer TS function params to `React.FC`:
+
+## Implicit `children` prop
+
+`React.FC` implicitly adds some extra properties to the component — notably `props.children`
+
+```tsx
+type Props = {
+	className?: string;
+};
+
+// `children` is allowed here, no type error!
+const Example: React.FC<Props> = ({ className, children }) => {
+	return <div className={className}>{children}</div>;
+};
+```
+
+When you use regular TypeScript function parameters, `children` now results in a TS error
+
+```tsx
+type Props = {
+	className?: string;
+};
+
+// 🚨 TypeError: Property 'children' does not exist on type 'Props'.ts(2339)
+const Example = ({ className, children }: Props) => {
+	return <div className={className}>{children}</div>;
+};
+```
+
+This can be fixed by explicitly typing the `children` prop
+
+```tsx
+import { ReactNode } from 'react';
+type Props = {
+	className?: string;
+	children: ReactNode;
+};
+
+const Example = ({ className, children }: Props) => {
+	return <div className={className}>{children}</div>;
+};
+```
+
+`children` _is_ another prop that's part of your component's interface. So having to be explicit about when it is/isn't allowed is a good thing.
+
+## Shorter / less boilerplate
+
+Ditching `React.FC` also happens to be less code when declaring components.
+
+```tsx
+// #1. TS params
+const Comp1 = (props: Props) => <div />;
+// #2, TS params w/ explicit return type
+const Comp2 = (props: Props): JSX.Element => <div />;
+// #3. React.FC
+const Comp3: React.FC<Props> = (props) => <div />;
+```
+
+**Less characters typed doesn't always equal more readability!!** However, in this case, I think option #1 (TS params + return type inference) is a much lighter syntax.
+
+## Generic types
+
+Depending on the type of projects you work on, you may or may not use generics heavily. However, if you're working on abstractions like component libraries and general utility components you'll probably need to know a bit about TS generics.
+
+> If you're not familiar with TypeScript generics, check out [this overview](/typescript-generics) to learn more.
+
+With the simpler TS parameter syntax, you can more easily create generic components that _infer_ their types based on the props provided.
+
+```tsx
+type Props<T> = {
+	value: T;
+	onClick: (value: T) => void;
+};
+
+const Button = <T extends any>({ value, onClick }: Props<T>) => {};
+
+const Example = () => {
+	return (
+		<>
+			<Button
+				value="a"
+				// type of `value` here is "string"
+				onClick={(value) => console.log(value)}
+			/>
+			<Button
+				value={100}
+				// type of `value` here is "number"
+				onClick={(value) => console.log(value)}
+			/>
+		</>
+	);
+};
+```
+
+This is extremely powerful since you can provide rock-solid type declarations while still having dynamic, abstract components. And it's significantly more difficult (impossible?) with `React.FC`
+
+## Further reading
+
+- Create React App's [decision](https://github.com/facebook/create-react-app/pull/8177) to move away from `React.FC`
+- [Spotify ADR](https://backstage.io/docs/architecture-decisions/adrs-adr006) documenting moving away from `React.FC`

--- a/apps/website-sv/src/content/drafts/simple-feature-flagging-with-environment-variables.md
+++ b/apps/website-sv/src/content/drafts/simple-feature-flagging-with-environment-variables.md
@@ -1,0 +1,13 @@
+---
+title: Simple feature flagging with environment variables
+date: 2022-02-15
+tags:
+  - feature-flags
+  - software-engineering
+---
+
+- intro: what's a feature flag and why do we care?
+
+- segue: use the simplest possible flagging solution you can.
+
+- tutorial: how to do it with environment variables.

--- a/apps/website-sv/src/content/drafts/ssr-is-not-more-complex.md
+++ b/apps/website-sv/src/content/drafts/ssr-is-not-more-complex.md
@@ -1,0 +1,59 @@
+---
+title: Server-rendering your frontend app isn't "too complex"
+description: In fact, it might result in a simpler app overall.
+tags:
+  - http
+  - software-engineering
+---
+
+A common pushback I hear regarding server-rendering is that "we don't need the added complexity because {insert reason here}". And while I applaud the goal of reducing complexity, I'm not sure taking SSR off the table actually reduces complexity.
+
+In fact, your 100% client-rendered application might be _more_ complex than if you had server-rendered it. Here's why:
+
+## SSR isn't hard to set up
+
+These days most frontend frameworks will support some form of SSR with minimal config. In the React world alone you've got a few great options to pick from:
+
+- Remix
+- Next.js
+- Blitz.js
+- Redwood.js
+- ...and many more ✨
+
+## Some things are inherently easier on the server
+
+At a former job I remember one team having to do some significant rework to make user personalization happen on their client-rendered React app. This would have been much easier had they defaulted to a server-rendered model.
+
+Another example of something that's easier on the server is caching. On the server, you can easily cache requests in a data store like Redis or Memcached with minimal configuration. You can also send `Cache-Control` headers with your responses to help browsers cache data.
+
+In client-rendered React apps, it's usually an in-memory store (read: more JS running) caching API requests for the duration of the session. While this may _seem_ simple, it's a massive headache and a huge surface area for bugs.
+
+## Data flow is more direct on the server
+
+On the server you have a controlled environment where the "lifetime" of a request can be visualized in a fairly linear fashion:
+
+1. Data enters your server via the URL (route + params)
+2. Relevant data is fetched (or mutated) from the database or underlying microservices.
+3. HTML is rendered and sent to the browser
+4. Finally, JS sprinkles extra interactivity and pizzazz.
+
+The client is more flakey. You're bound to the whims of the user's network. Not to mention that now you have to think about concurrent API requests, race conditions, state management, and caching _in your frontend code_.
+
+You'll find that if you keep your client "thinner" (less state and more syncing to the server) data flow just becomes waaaaay easier to understand.
+
+## It's easier to squeeze perf out of your servers than your client
+
+Got a page that's rendering slowly in a server-rendered app?
+
+- Slow DB query (cache + optimize the query)
+- Slow microservice (cache + fix the service)
+- High memory load (scale horizontally / bump RAM while you work on lowering memory load)
+
+In short, you have the _agency_ to fix the cause behind the slowness quickly.
+
+You have no control over your users' devices — a fully client-rendered app could be slow for a myriad of reasons you don't control.
+
+- Internet speed (nothing you can do!)
+- Cheap device (low RAM) (nothing you can do!)
+- Request waterfalls (["spinnageddon"](https://twitter.com/ryanflorence/status/1186519682272022528))
+- Too much JS running (have to limit dependencies and do profiling work)

--- a/apps/website-sv/src/content/drafts/strangler-fig-sveltekit.md
+++ b/apps/website-sv/src/content/drafts/strangler-fig-sveltekit.md
@@ -1,0 +1,9 @@
+- need to set up endpoints to proxy the old app (in my case, Next.js required 2)
+
+  - `src/routes/[...path].ts` and `src/routes/_next/[...path].ts`
+
+- then, start migrating your pages 1 by 1!
+
+  - if your pages are prerendered (mine were), make sure to set `kit.prerender.crawl = false` in your `svelte.config.js` while you're migrating routes in the "middle" of your URL architecture. Otherwise you might find that the crawler will hit your proxy endpoints and store the HTML. Could depend on the hosting provider, but on Vercel this resulting in the HTML being _downloaded_ instead of _served_ in Chrome.
+
+- Note: my website currently doesn't have any data mutations. If you have data mutations strangler fig approach is gonna be a lot harder. But at a high level it's gonna be the same approach. Chances are you'll find that you want to store _less_ in frontend in-memomry state while migrating and sync things either to persistent browser memory or the server. That way you can easily hand things off between each app and migrate based on pages.

--- a/apps/website-sv/src/content/drafts/web-platform-evolution.md
+++ b/apps/website-sv/src/content/drafts/web-platform-evolution.md
@@ -1,0 +1,20 @@
+---
+title: Evolution of the web platform
+subtitle: Things that now exist just by "using the platform"
+tags:
+  - fundatmentals
+  - front-end
+  - software-engineering
+---
+
+- TL;DR
+
+  - Browsers have come a long way in the last 5 years, and now support many things natively that were previously only in "userland". As such, the web platform grows more and more powerful and we're able to "use the platform" more and more.
+
+- Resources
+  - [The balance has shifted away from SPAs](https://nolanlawson.com/2022/05/21/the-balance-has-shifted-away-from-spas/)
+  - [In defense of the modern web](https://dev.to/richharris/in-defense-of-the-modern-web-2nia)
+
+<!--
+Related: "use the platform" and adoption curves
+ -->

--- a/apps/website-sv/src/content/intro.md
+++ b/apps/website-sv/src/content/intro.md
@@ -1,0 +1,3 @@
+staff+ frontend engineer. i specialize in design systems, frontend architecture, and taking products from 0 → 1.
+
+currently @ [sublime.security](https://sublime.security).

--- a/apps/website-sv/src/content/markdown-test.md
+++ b/apps/website-sv/src/content/markdown-test.md
@@ -151,6 +151,24 @@ nothing changed
 - deleted
 ```
 
+---
+
+## Images
+
+![placeholder img](https://placehold.co/1600x400)
+
+---
+
+## Tables
+
+| name   | emoji | fruit | wiki                                 |
+| ------ | ----- | ----- | ------------------------------------ |
+| potato | 🥔    | ❌    | https://en.wikipedia.org/wiki/Potato |
+| tomato | 🍅    | ✅    | https://en.wikipedia.org/wiki/Tomato |
+| banana | 🍌    | ✅    | https://en.wikipedia.org/wiki/Banana |
+
+---
+
 ## Callouts
 
 > [!NOTE]

--- a/apps/website-sv/src/content/markdown-test.md
+++ b/apps/website-sv/src/content/markdown-test.md
@@ -1,0 +1,186 @@
+# Heading Level 1
+
+## Heading Level 2
+
+This is a paragraph of text following the h2. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+### Heading Level 3
+
+This is a paragraph of text following the h3. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+#### Heading Level 4
+
+This is a paragraph of text following the h4. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+##### Heading Level 5
+
+This is a paragraph of text following the h5. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+###### Heading Level 6
+
+This is a paragraph of text following the h6. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+---
+
+## Paragraphs
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+---
+
+## Text Styling
+
+Here is a paragraph that contains **a bit of bold text to show what that looks like**. Then for a little bit do regular to separate it from _the italics portion_. Lastly, [here's a link]() to nowhere.
+
+---
+
+## Lists
+
+For now the horizontal rhythm of these two list types are different because that's what feels right...rarely would you see a bulletted list immediately following a numbered list though 😎
+
+### Ordered
+
+1. Item
+1. Item
+1. Item
+1. Item
+   1. Inner
+   2. Inner
+1. Item
+1. Item
+1. Item
+1. Item
+
+### Unordered
+
+- Item
+  - Sublisted item
+  - Sublisted item
+  - Sublisted item
+- Item
+- Item
+- Item
+- Item
+
+---
+
+## BlockQuote
+
+In paragraphs for context.
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+> Here is the first line of the blockquote, a really long line that should wrap around on most screens
+>
+> And another line to see a little bigger
+>
+> Lastly, a third line
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+---
+
+## Code/Preformatted
+
+Here's a paragraph to show what `inline code blocks` look like...they won't be syntax highlighted, which is a good thing.
+
+```
+and this is a code block w/o highlighting...
+```
+
+### JavaScript
+
+```javascript
+// this has a comment above it.
+const greeting = (name) => `Hello ${name}`;
+
+console.log(greeting("world"));
+```
+
+### JSX
+
+```jsx
+const Button = (props) => (
+	<button
+		onClick={() => {
+			alert("hello");
+		}}
+	>
+		welcome!
+	</button>
+);
+```
+
+### HTML
+
+In paragraphs for context.
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit.
+
+```html
+<div class="sample">
+	<button class="button">click me!</button>
+</div>
+```
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+### CSS
+
+```css
+:root {
+	--color-primary: #333;
+}
+
+.selector {
+	color: var(--color-primary);
+	background: papayawhip;
+	mask-image: url("https://localhost:3000/image.png");
+}
+```
+
+### Diff
+
+```diff
+nothing changed
++ added
+- deleted
+```
+
+## Callouts
+
+> [!NOTE]
+>
+> This is a note. You can use this to talk about quick asides and things that are somewhat tangential to the main point.
+>
+> You can make it as long as you want, even multiple paragraphs!
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!TIP]
+>
+> This is a tip. You can use it for basic helper tips that would clutter up the main
+> body of text
+>
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!IMPORTANT]
+>
+> **This is an important callout.** Use it to call attention to things that shouldn't be ignored or are...well...important.
+>
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!WARNING]
+>
+> This is a warning. Use it to highlight things that probably aren't correct anymore, or that you probably shouldn't do.
+>
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!CAUTION]
+>
+> This is a caution callout. Use this for things that are actually really bad and you want to call attention to it.
+>
+> This one also has a [link to google](https://google.com) and a `inline code`

--- a/apps/website-sv/src/content/notes/building-an-infinite-scrolling-list-with-react/VirtualizedList.tsx
+++ b/apps/website-sv/src/content/notes/building-an-infinite-scrolling-list-with-react/VirtualizedList.tsx
@@ -1,0 +1,230 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import debounce from "lodash/debounce";
+
+const SCROLL_DEBOUNCE_TIME = 200;
+
+interface GetPartialPageHeightArguments {
+	items: number;
+	itemsPerPage: number;
+	rowHeight: number;
+	columns: number;
+	offsetY: number;
+}
+
+/**
+ * Utility function to return the height of the final page. Within the list of
+ * items, the final page sometimes can be a partial page.
+ *
+ * This function figures out how many rows of items exist on the final page
+ * of the list and returns the calculated height of the page.
+ */
+const getPartialPageHeight = ({
+	items,
+	itemsPerPage,
+	rowHeight,
+	columns,
+	offsetY,
+}: GetPartialPageHeightArguments) => {
+	const numberOfPages = items / itemsPerPage;
+	const completePages = Math.floor(numberOfPages);
+
+	if (completePages === numberOfPages) {
+		const rows = itemsPerPage / columns;
+		return rows * rowHeight;
+	}
+
+	const lastPageStartIndex = completePages * itemsPerPage - 1;
+	const itemsOnLastPage = items - lastPageStartIndex - 1;
+	const lastPageRows = Math.ceil(itemsOnLastPage / columns);
+
+	return lastPageRows * rowHeight + offsetY;
+};
+
+/**
+ * Given an HTML element and the static height of each page, determine which
+ * page index the user is currently scrolled on.
+ *
+ * For the purposes of this function, the user is scrolled on a page once the page
+ * has intersected with the TOP of the window. This is an explicit trade-off for
+ * the sake of simplicity.
+ */
+const getCurrentScrollPage = (wrapper: HTMLElement, pageHeight: number) => {
+	const wrapperScrollOffset = wrapper.offsetTop;
+	const scrollPosition = window.scrollY;
+
+	const currentScrollPage = Math.floor(
+		(scrollPosition - wrapperScrollOffset) / pageHeight,
+	);
+
+	return Math.max(currentScrollPage, 0);
+};
+
+interface VirtualizedListPageProps {
+	children: ReactNode;
+	pagesBefore: number;
+	pageHeight: number;
+	lastPageHeight: number;
+	isLastPage?: boolean;
+	className?: string;
+	offsetY?: number;
+}
+
+/**
+ * A single "page" of items within the virtual list. Each page will be absolutely
+ * positioned based on its index and toggled based on the current scroll position.
+ */
+const VirtualizedListPage = ({
+	children,
+	pagesBefore,
+	pageHeight,
+	className,
+	isLastPage = false,
+	lastPageHeight,
+	offsetY = 0,
+}: VirtualizedListPageProps) => {
+	const height = isLastPage ? lastPageHeight : pageHeight;
+	return (
+		<div
+			className={className}
+			style={{
+				position: "absolute",
+				top: pagesBefore * pageHeight,
+				height: height + offsetY,
+				marginBottom: -1 * offsetY,
+				overflow: "hidden",
+				width: "100%",
+				boxSizing: "border-box",
+			}}
+		>
+			{children}
+		</div>
+	);
+};
+
+interface VirtualizedListProps {
+	renderPage: (index: number) => ReactNode;
+	items: number;
+	itemsPerPage: number;
+	/**
+	 * Number of columns per row in the page. This allows you to create grids with
+	 * your items and dynamically size the item widths. Defaults to `1`
+	 */
+	columns?: number;
+	rowHeight: number;
+	pageOffsetY?: number;
+}
+
+/**
+ * Renders a virtualized list.
+ *
+ * The primary reason for using a virtualized list is _performance_—rendering large
+ * lists of items throws a ton of elements into the DOM.
+ *
+ * While rendering 20-50 elements doesn't result in degraded performance, you might
+ * start to see dropped frames around 100-200 items, and the browser can potentially
+ * crash when you render 1,000+ items.
+ *
+ * This virtualized list using a technique called "windowing". For further reading
+ * on windowing techniques check out https://web.dev/virtualize-long-lists-react-window/.
+ */
+export const VirtualizedList = ({
+	renderPage,
+	columns = 1,
+	rowHeight,
+	items,
+	itemsPerPage,
+	pageOffsetY = 0,
+}: VirtualizedListProps) => {
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	const [currentPageIndex, setCurrentPageIndex] = useState(0);
+
+	const pages = Math.ceil(items / itemsPerPage);
+
+	const rowsPerPage = itemsPerPage / columns;
+	const pageHeight = rowsPerPage * rowHeight + pageOffsetY;
+	const lastPageStartIndex = pages - 1;
+
+	// Since the last page can be a partial page, determine its height separately
+	// from the rest.
+	const lastPageHeight = getPartialPageHeight({
+		items,
+		itemsPerPage,
+		columns,
+		rowHeight,
+		offsetY: pageOffsetY,
+	});
+
+	const pagesBefore = currentPageIndex;
+	const pagesAfter = lastPageStartIndex - currentPageIndex;
+
+	// NOTE: it's important to figure out the current page based on SCROLL POSITION
+	// rather than attempting to use an IntersectionObserver.
+	//
+	// Using an IntersectionObserver worked when scrolling slowly, but it didn't
+	// correctly toggle pages when scrolling quickly or when scrubbing the scroll bar.
+	// This is because you skip right past the entire IntersectionObserver and
+	// immediately scroll into empty space.
+	useEffect(() => {
+		const wrapper = wrapperRef.current;
+		if (!wrapper) return;
+
+		const handleScroll = debounce(() => {
+			const currentScrollPage = getCurrentScrollPage(wrapper, pageHeight);
+			setCurrentPageIndex(currentScrollPage);
+		}, SCROLL_DEBOUNCE_TIME);
+
+		window.addEventListener("scroll", handleScroll, { passive: false });
+
+		return () => {
+			window.removeEventListener("scroll", handleScroll);
+		};
+	}, [pageHeight]);
+
+	return (
+		<>
+			<div
+				ref={wrapperRef}
+				style={{
+					position: "relative",
+					overflow: "hidden",
+					marginBottom: pageOffsetY * -1,
+					paddingBottom: pageOffsetY,
+					height: lastPageStartIndex * pageHeight + lastPageHeight,
+				}}
+			>
+				{pagesBefore > 0 && (
+					<VirtualizedListPage
+						pageHeight={pageHeight}
+						lastPageHeight={lastPageHeight}
+						pagesBefore={pagesBefore - 1}
+						offsetY={pageOffsetY}
+					>
+						{renderPage(currentPageIndex - 1)}
+					</VirtualizedListPage>
+				)}
+
+				<VirtualizedListPage
+					pagesBefore={pagesBefore}
+					pageHeight={pageHeight}
+					isLastPage={currentPageIndex === lastPageStartIndex}
+					lastPageHeight={lastPageHeight}
+					offsetY={pageOffsetY}
+				>
+					{renderPage(currentPageIndex)}
+				</VirtualizedListPage>
+
+				{pagesAfter > 0 && (
+					<VirtualizedListPage
+						pageHeight={pageHeight}
+						isLastPage={currentPageIndex + 1 === lastPageStartIndex}
+						lastPageHeight={lastPageHeight}
+						pagesBefore={pagesBefore + 1}
+						offsetY={pageOffsetY}
+					>
+						{renderPage(currentPageIndex + 1)}
+					</VirtualizedListPage>
+				)}
+			</div>
+		</>
+	);
+};

--- a/apps/website-sv/src/content/notes/building-an-infinite-scrolling-list-with-react/index.mdx
+++ b/apps/website-sv/src/content/notes/building-an-infinite-scrolling-list-with-react/index.mdx
@@ -1,0 +1,215 @@
+---
+title: Building an infinite-scrolling list with React
+date: 2020-02-02T00:00:00.000Z
+tags:
+  - react
+  - typescript
+  - tutorials
+---
+
+## Intro
+
+### Do you _need_ an infinite list?
+
+### List virtualization and "windowing"
+
+### Why build it from scratch instead of {insert library here}?
+
+- Small, focused bundle size
+- Ability to customize and tweak to fit your needs.
+  - for example, if you want to allow the list to change the height of the window. (or to have it NOT change the height of the window).
+- Support for _pages_ of items and _grids_. This is a big one for the infinite lists I've built in the past. Most virtualization libraries supply the tools to do 1-dimensional lists fairly easily, or they allow virtualizing on both the x- and y-axis. So, doing a virtualized y-axis with a grid of items on the x-axis results in a lot of effort, equal to building the whole dang virtualized list yourself.
+- Deep knowledge of list virtualization. If you're building web apps, it's a good thing to know, and allows you to wow clients (or product managers) while still providing a good user experience.
+
+### Creating a good infinite scroll experience
+
+- ability to handle any number of items with smooth framerates while scrolling
+- ability to "load more" when the bottom of the list is reached
+- scroll scrubbing with lazy-loading
+- smaller bundle size than `react-window` (granted, it will also have a smaller feature set)
+- does not overflow or have weird spacing at the bottom of the list.
+- allows us to handle responsive sizing in _some_ fashion.
+
+## Let's build it!
+
+### Set up the shell of our list
+
+```tsx
+import React from 'react';
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+}
+
+export const VirtualizedList = ({ total, rowHeight }: VirtualizedListProps) => {
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: rowHeight * total
+			}}
+		></div>
+	);
+};
+```
+
+- inline styles for simplicity
+- light gray as "background" for now
+- we add 2 props to our list
+  - the total count of items we plan on rendering
+  - the height of each individual row. For now we're assuming that each row contains 1 item.
+- Finally, we use the count of total items and the height of each individual row to get the full height of our list.
+
+### Split our total count of items into "pages"
+
+```tsx
+import React from 'react';
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+	pageSize: number;
+}
+
+export const VirtualizedList = ({ total, rowHeight, pageSize }: VirtualizedListProps) => {
+	const pages = Math.ceil(total / pageSize);
+	const pageHeight = pageSize * rowHeight;
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: pageHeight * pages
+			}}
+		></div>
+	);
+};
+```
+
+- Add 1 more prop, now the amount of items in a "page".
+- Now, instead of calculating by the number of rows, we'll be calculating the total height by the number of "pages". Right now we only are rendering 1 item per row so the calculation will be fairly straightforward.
+
+### Fix the last page
+
+```tsx
+import React from 'react';
+
+type GetLastPageHeight = (args: { total: number; pageSize: number; rowHeight: number }) => number;
+
+const getLastPageHeight: GetLastPageHeight = ({ total, pageSize, rowHeight }) => {
+	const pages = total / pageSize;
+	const completePages = Math.floor(pages);
+
+	if (completePages === pages) {
+		return pageSize * rowHeight;
+	}
+
+	const lastPageStartIndex = completePages * pageSize - 1;
+	const itemsOnLastPage = total - lastPageStartIndex - 1;
+
+	return itemsOnLastPage * rowHeight;
+};
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+	pageSize: number;
+}
+
+export const VirtualizedList = ({ total, rowHeight, pageSize }: VirtualizedListProps) => {
+	const pages = Math.ceil(total / pageSize);
+	const pageHeight = pageSize * rowHeight;
+	const lastPageStartIndex = pages - 1;
+	const lastPageHeight = getLastPageHeight({
+		total,
+		rowHeight,
+		pageSize
+	});
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: pageHeight * lastPageStartIndex + lastPageHeight
+			}}
+		></div>
+	);
+};
+```
+
+- the list works great if the number of items evenly divides by the page size, but if it _doesn't_ we're left with some extra space at the bottom of the list. To get the height to be _exactly_ the number of items, we need to add some calculation for the final page of items.
+- we calculate how many complete pages exist, if that's the same as the total # of pages, then our calculation is more straightforward. Otherwise, we have to do a little extra math to figure out how many rows exist on the final page.
+
+### Add the ability to render a custom page of items
+
+```tsx
+import React, { Fragment, ReactNode } from 'react';
+
+type GetLastPageHeight = (args: { total: number; pageSize: number; rowHeight: number }) => number;
+
+const getLastPageHeight: GetLastPageHeight = ({ total, pageSize, rowHeight }) => {
+	const pages = total / pageSize;
+	const completePages = Math.floor(pages);
+
+	if (completePages === pages) {
+		return pageSize * rowHeight;
+	}
+
+	const lastPageStartIndex = completePages * pageSize - 1;
+	const itemsOnLastPage = total - lastPageStartIndex - 1;
+
+	return itemsOnLastPage * rowHeight;
+};
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+	pageSize: number;
+	renderPage: (index: number) => ReactNode;
+}
+
+export const VirtualizedList = ({
+	total,
+	rowHeight,
+	pageSize,
+	renderPage
+}: VirtualizedListProps) => {
+	const pages = Math.ceil(total / pageSize);
+	const pageHeight = pageSize * rowHeight;
+	const lastPageStartIndex = pages - 1;
+	const lastPageHeight = getLastPageHeight({
+		total,
+		rowHeight,
+		pageSize
+	});
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: pageHeight * lastPageStartIndex + lastPageHeight
+			}}
+		>
+			{Array.from({ length: pages }).map((_, index) => (
+				<div
+					key={index}
+					style={{
+						height: index === lastPageStartIndex ? lastPageHeight : pageHeight
+					}}
+				>
+					{renderPage(index)}
+				</div>
+			))}
+		</div>
+	);
+};
+```
+
+## Conclusion
+
+### Some next steps
+
+- Allow dynamically determining a page's size. In `react-window` this is called `VariableSizedList`
+
+### Resources
+
+- https://web.dev/virtualize-long-lists-react-window
+  /

--- a/apps/website-sv/src/content/notes/code-comments.mdx
+++ b/apps/website-sv/src/content/notes/code-comments.mdx
@@ -1,0 +1,56 @@
+---
+title: Code comments
+date: 2021-01-01T23:31:41.255Z
+tags:
+  - documentation
+  - tech-debt
+  - philosophy
+  - clean-code
+---
+
+## Thoughts in favor of comments
+
+- Commenting acknowledges that our concepts of what is "clean code" changes over time. Our preferences 20 years from now won't be the exact same as our preferences right now. Sure, _some_ will, but not all.
+- [A codebase is an organism](https://meltingasphalt.com/a-codebase-is-an-organism/), and comments acknowledge that this organism has a life of its own. Especially if you work on a high-velocity team with rapidly changing direction (startups), comments can be a lifesaver when you've written 10,000+ lines in the last 6 months.
+- There's a lot of bad comments out there. The solution isn't to ditch comments entirely, that's throwing the baby out with the bathwater.
+- Code comments are a lower _barrier to information_ than code. Sure, you can make code self-explanatory, but guess what's even more explanatory than code? Sentences.
+- Commenting isn't a science, it's an art. To write good comments, you have to become a _good writer_. There's no "One True Way", it's a little more convoluted and messy.
+- Code comments are an acknowledgement of human finiteness and imperfection. In a perfect world, we would write perfect code and have perfect knowledge of the code others wrote. We will never achieve this goal because we as humans are not perfect. Leaving comments in our code is a recognition that our code will never be perfect, but we can help the next person understand it a little better.
+
+## Anti-comment sentiment
+
+- Bob Martin says a comment is "an admission of failure to write good code". The idea is that instead of writing the comment, you should focus on rewriting the code to be clearer and more explanatory. This is _the line_ that most anti-comment sentiment stems from.
+- Another anti-comment sentiment is that the added context a comment provides can be put in a commit message or pull request. However, this fails to address to the barrier to information issue—finding a commit or PR requires some digging (especially if the file has a high churn rate).
+- Another objection to code comments and documentation is that unit tests can capture requirements in the same way a comment can. While unit tests do capture some acceptance criteria, I find that A) they serve a slightly different purpose from documentation, and B) they often get left out when the rubber meets the road.
+- Ironically, the chapter in "Clean Code" about comments _does not advocate for a no-comments-ever approach_. Rather, it discusses Martin's opinions about "good" comments and "bad" comments. And there's quite a bit in there about when comments are helpful.
+- Also ironically, a lot of anti-comment sentiment _written in books and on blogs_ is more moderate than anti-comment sentiment I've experienced in real life. I think one reason behind this is that anti-comment posts rely on flashy titles and blanket statements ("You shouldn't comment your code") and then backtrack into a more moderate position ("Don't use comments to paper over bad code"). But people read the polarizing blanket statement and walk away with the takeaway "Good code doesn't have comments, bad code does".
+
+## Some commenting guidelines
+
+- Commenting intent. The most valuable comments describe _why the code is the way that it is_. For example, is the code written to solve a specific edge case or bug? Or does it need to be a certain for performance or cross-platform compatability?
+- Use complete thoughts. For most comments, this means using complete sentences. However, I find myself also writing comments in an imperative voice—essentially prefixing my comment with an unwritten "This code..." before I describe the block of code.
+  - Why complete thoughts? Capturing a complete thought forces you to slow down and reflect on how to make the comment most valuable.
+  - Complete thoughts are easier for others to read. We're used to reading in complete sentences, most of us have been doing it since we were little kids.
+- If you do include a URL in your comment, add some extra context.
+  - This helps keep the comment skimmable and allows the reader to understand whether they need the additional information following the URL would provide.
+  - This helps with the shelf life of the comment as well. URLs can move or become invalid. Your company can cancel their JIRA account or move code from GitHub to GitLab. Capturing a tiny bit of context around the URL means that your comment might outlive the URL.
+- Take advantage of block comments. Most languages provide a block comment syntax that gets picked up by modern IDEs. This allows other engineers using your code to get a basic description of your code through intellisense.
+  - If you're in a dynamically typed language, block comments usually provide a syntax for documenting input/output shapes as well. For an example check out JSDoc's [`@param`](https://jsdoc.app/tags-param.html) and [`@returns`](https://jsdoc.app/tags-returns.html) tags.
+- ["Space shuttle style"](https://www.github.com/kubernetes/kubernetes/tree/ec2e767e59395376fa191d7c56a74f53936b7653/pkg%2Fcontroller%2Fvolume%2Fpersistentvolume%2Fpv_controller.go) (from the Kubernetes source code). This is probably the heaviest commenting style I've seen, but it draws inspiration from the [Apollo-11 source code](https://github.com/chrislgarry/Apollo-11). This style can be a useful tool for mission critical code where robust documentation is absolutely required.
+- When in doubt, err on the side of adding the comment. It's better to delete a redundant comment 6 months down the road than it is to wish you had written it down 6 months later. Over time your gut feeling of "should I write a comment?" will get more and more accurate.
+
+## Resources
+
+### Pro-comment sentiment
+
+- [Google's tech writing guides](https://developers.google.com/tech-writing/two/code-comments)
+- [“Good code documents itself” and other hilarious jokes you shouldn’t tell yourself](https://hackaday.com/2019/03/05/good-code-documents-itself-and-other-hilarious-jokes-you-shouldnt-tell-yourself/)
+- [Comment your f\*\*\*ing code](http://blog.codefx.org/techniques/documentation/comment-your-fucking-code/)
+- [Documentation is JSON for the Brain](https://www.ericholscher.com/blog/2017/feb/13/docs-are-json-for-the-brain)
+- ["My code is self-documenting"](https://www.ericholscher.com/blog/2017/jan/27/code-is-self-documenting/)
+
+### Anti-comment sentiment
+
+- [Clean code](https://www.oreilly.com/library/view/clean-code-a/9780136083238/), notably Chapter 4 which deals with comments.
+- [Do not comment bad code - rewrite it](https://www.ralin.io/blog/do-not-comment-bad-code-rewrite-it.html)
+- [Why You Shouldn't Comment (or Document) Code](https://visualstudiomagazine.com/articles/2013/06/01/roc-rocks.aspx)

--- a/apps/website-sv/src/content/notes/finite-state-machines.mdx
+++ b/apps/website-sv/src/content/notes/finite-state-machines.mdx
@@ -1,0 +1,14 @@
+---
+title: Finite State Machines
+date: 2021-01-29T00:00:00.000Z
+tags:
+  - programming
+---
+
+## What is a Finite State Machine, anyway?
+
+Finite state machines (FSM) have been around for a long time. Even though they're just now enjoying a surge of popularity, they're based on mathematic
+
+## Resources
+
+- https://xstate.js.org/docs/

--- a/apps/website-sv/src/content/notes/friendly-vs-unfriendly-iframes.mdx
+++ b/apps/website-sv/src/content/notes/friendly-vs-unfriendly-iframes.mdx
@@ -1,0 +1,30 @@
+---
+title: Friendly vs unfriendly iframes
+date: 2021-01-07T00:00:00.000Z
+tags:
+  - front-end
+  - html
+  - security
+---
+
+### Definition
+
+A **friendly `iframe`** has the same domain as its parent document.
+
+In contrast, an **unfriendly `iframe`** has a different `src` domain than its parent.
+
+### Differences
+
+The key difference between friendly and unfriendly `iframe`s boils down to the level of access afforded by the embedded document.
+
+In a friendly `iframe`, the embedded document has access to the parent's `window` object and can change things in the parent.
+
+However, an unfriendly `iframe` is bound by `same-origin policy` and does _not_ have access to the parent document's `window` object.
+
+### Why does it matter?
+
+The primary reason that an `iframe` is more restricted if it comes from another domain is _security_. That `iframe` comes from a domain that you "don't control". Even if you actually _do_ control the domain—there's no way of letting the browser know that.
+
+And if you _are_ iframing a site that you don't own, it's possible that the external site gets hacked, or introduces some invasive code. If they had access to your site's `window` object you've suddenly also been hacked! 😱
+
+This means that your "hostile" `iframe`s can only talk to their parent document via [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage). This builds security into the cross-site communication since the parent document has to explicitly listen for and interprest the message sent from the `iframe`.

--- a/apps/website-sv/src/content/notes/nextjs-file-structure.mdx
+++ b/apps/website-sv/src/content/notes/nextjs-file-structure.mdx
@@ -1,0 +1,66 @@
+---
+title: NextJS file structure
+date: 2021-02-04T00:00:00.000Z
+tags:
+  - nextjs
+  - react
+  - architecture
+  - file-structure
+---
+
+## Guiding principles behind a file structure
+
+- **Flexibility.** A good file structure allows for evolution—it makes it easy to delete code and move files around.
+- **Colocation.** We want to keep relevant code together to minimize context switching and digging through the filesystem.
+- **Simplicity.** We don't want some elaborate file structure that takes 20 minutes to explain. Ideally we can describe the core principles of a structure in a couple sentances.
+
+## Use a flat file structure for small apps
+
+For small NextJS apps I like to keep my file structure flat.
+
+```
+my-project
+└─ api
+│     └─  login.ts
+│     └─  posts.ts
+└─ components
+│     └─  __tests__
+│     │     └─  Button.test.tsx
+│     │     └─  Card.test.tsx
+│     └─  Button.tsx
+│     └─  Card.tsx
+└─ lib
+│     └─  __tests__
+│     │     └─  handleUserInput.test.ts
+│     │     └─  useDebounce.test.tsx
+│     └─  handleUserInput.ts
+│     └─  useDebounce.ts
+│     └─  fetchPosts.ts
+└─ integration
+│     └─  index.test.ts
+│     └─  about.test.ts
+│     └─  sign-up.test.ts
+└─ test-utils
+│     └─  setupTests.ts
+│     └─  renderPage.ts
+└─ pages
+│     └─  index.tsx
+│     └─  about.tsx
+│     └─  sign-up.tsx
+└─ styles
+│     └─  reset.css
+
+```
+
+## Group by feature for large apps
+
+```
+my-project
+└─ features
+│     └─  blog
+│     │     └─  api
+│     │     └─  lib
+│     │     └─  integration
+│     │     └─  components
+│     │     └─  pages
+```

--- a/apps/website-sv/src/content/notes/php-cheatsheet.mdx
+++ b/apps/website-sv/src/content/notes/php-cheatsheet.mdx
@@ -1,0 +1,62 @@
+---
+title: PHP cheatsheet
+date: 2021-01-14T00:00:00.000Z
+---
+
+## Declaring variables
+
+```php
+$variable = 'value';
+```
+
+## Object operator (`->`)
+
+```php
+// Create an object
+$obj = new stdClass();
+
+// Set a property on an object
+$obj->prop = 'test';
+
+// Get a property on an object
+$prop = $obj->prop;
+print( $prop ); // test
+
+// Call a method on an object
+$obj->method();
+```
+
+## "Arrays"
+
+PHP arrays are _very_ different than JavaScript arrays. They're more similar to JavaScript _objects_, even though they use the square bracket syntax.
+
+```php
+$arr = [
+  'key1' => 'val', // the => assigns the value to the key
+  'key2' => 'val2'
+];
+```
+
+The equivalent JS code would be something like this:
+
+```js
+const arr = {
+	key1: 'val',
+	key2: 'val2'
+};
+```
+
+In addition, you _can_ use a PHP `array` as a sorted, unkeyed list (similar to a JS array), in that case you would use the array syntax _without_ the key syntax
+
+```php
+$arr = [
+  'val', // key is 0
+  'val2' // key is 1
+];
+```
+
+To access an array value, you can use the square brackets along with the key name:
+
+```php
+$arr['key'];
+```

--- a/apps/website-sv/src/content/notes/programming-benchmarks.mdx
+++ b/apps/website-sv/src/content/notes/programming-benchmarks.mdx
@@ -1,0 +1,60 @@
+---
+title: Programming Benchmarks
+date: 2021-01-01T23:31:41.255Z
+---
+
+## Why is a programming benchmark useful?
+
+> ⚠️ WIP
+
+- Lets you compare methods of solving the same problem.
+- Allows you to focus on the _mechanics_ of a language or framework.
+- Allows you to work within a _domain_ that you're already familiar with.
+
+## Marks of a great programming benchmark
+
+> ⚠️ TBD
+
+## Existing programming benchmarks
+
+### [TodoMVC](http://todomvc.com/)
+
+This is perhaps the most well-known full-stack benchmark out there. TodoMVC is great if you're trying to get familiar with a language or framework. However, it should be viewed as an "intro" to a framework rather than a comprehensive benchmark capable of highlighting strengths and weaknesses.
+
+### [Hacker News PWA](https://hnpwa.com/)
+
+Hacker News PWA is another common benchmark you'll see in the wild. It markets itself as a "spiritual successor to TodoMVC"—it's more complex and focuses on more modern technologies, especially progressive web apps.
+
+### [7GUIs](https://eugenkiss.github.io/7guis/)
+
+7GUIs is set of 7 exercises ranging from trivial (counter) to complex (spreadsheet). After you've done all 7 you should have a good feel for a language or framework. The only caveat (for me) is that it doesn't address some modern development challenges like data fetching (which has been [acknowledged by its creator](https://hackernoon.com/towards-a-better-gui-programming-benchmark-397aca3542b8), Eugen Kiss)
+
+## My own programming benchmarks
+
+Here's a few benchmarks I've used in the past when I'm exploring a framework or language.
+
+### Simple counter
+
+Usually the first thing I build after learning the basic syntax of a framework is a simple counter.
+
+These are the "acceptance criteria" for the counter benchmark:
+
+- The counter should display its current count and begin at 0.
+- The counter has three controls: `+`, `-`, and `Reset`.
+  - `+` adds 1 to the counter.
+  - `-` removes 1 from the counter. If the counter is already at `0`, `-` should do nothing (or be disabled).
+  - `Reset` sets the counter to `0`.
+
+What I like about the counter as a first benchmark is it is _very limited in scope_. This makes it great for a first foray into a new language or framework. This allows you to grow familiar with the basic syntax, simple state management, and simple rendering.
+
+### GitHub Repository Search
+
+> ⚠️ TBD
+
+### Login form
+
+> ⚠️ TBD
+
+## Some ideas for future benchmarks
+
+- Beer API filter + search (https://api.punkapi.com/v2/)

--- a/apps/website-sv/src/content/notes/python-syntax.mdx
+++ b/apps/website-sv/src/content/notes/python-syntax.mdx
@@ -1,0 +1,452 @@
+---
+title: Python syntax
+date: 2021-01-02T00:00:00.000Z
+tags:
+  - programming-languages
+  - python
+  - programming
+---
+
+## Bookmark
+
+https://docs.python.org/3.8/tutorial/modules.html
+
+## Version
+
+Python 3.8.x
+
+## Arithmetic
+
+- Division `(x / y)` _always returns a float_.
+- If you want to divide and round down (floor division), you can use the `//` division operator.
+- `%` returns the remainder (modulo)
+- `**` does an exponent
+- Mixing a floating point and integer in operations results in the a floating point conversion.
+
+## Variables
+
+- No "variable" operator, you can just use `=` to assign a variable: `name = value`
+
+## Strings
+
+- Single or double quotes
+- `\` as escape character
+- **raw string**: add `r` before the first quote to not escape `\` characters. `r'something with a \'
+- **multiline strings**: triple quotes `"""..."""`. Trailing backlash adds a new line to the string.
+- `+` concatenates strings. Strings next to each other are automagically concatenated (`'Py' 'thon'`). This doesn't work with variables, you'd have to use `+`
+- `*` repeats a string
+
+- Strings are _immutable_—instead of changing one, create a new one
+- String length with the built-in `len()` function
+
+## Lists
+
+- Designated with _square brackets_ (`nums = [1, 2, 3, 4, 5]`)
+- Indexing with square brackets (`nums[0]` returns `1`)
+- Slicing creates a new list from a subset (`nums[1:3]` returns `[2, 3, 4]`)
+- Slicing a complete _shallow copy_ of a list (`nums[:]`)
+- List concatenation with `+` operator (`[1, 2] + [3, 4, 5]` returns `[1, 2, 3, 4, 5]`)
+- Lists are _mutable_ so you can reassign values with the index access
+
+## Control Flow
+
+### `if` / `elif` / `else`
+
+- syntax is `if condition:` and then starts a new indentation block.
+- `elif` is a convenience keyword, essentially `else` + `if` to avoid an extra indentation block.
+
+### `for` loops
+
+- Notable difference to JS (C-style languages) is that the `for` _doesn't_ let you define the exit condition.
+- Rather, it only iterates over items in a sequence (like a list)
+
+```py
+planets = ['mercury', 'venus', 'earth', 'mars']
+
+for l in letters:
+  print(l, len(l))
+```
+
+- Instead of mutating collections inside an iteration, it's usually recommended to create a copy or a new collection.
+
+### `range`
+
+Gives you a range of numbers of length `n`
+
+```py
+# If only 1 argument, specifies the _length_
+range(5) # 0, 1, 2, 3, 4
+
+# If there's 2 arguments, 1st is start and 2nd is end (non-inclusive)
+range(5, 10) # 5, 6, 7, 8, 9
+
+# Third argument specifies the increment size
+range(0, 10, 3) # 0, 3, 6, 9
+```
+
+- Note that `range` _isn't a list_, even though it often behaves as such. It's an _iterable object_.
+
+### `break` & `continue` statements, `else` clauses in loops
+
+- `break` works exactly the same as JS—it breaks out of the current (innermost) loop.
+- A loop can have an `else` clause after the `for`. This run _if the loop terminates without executing anything in its body._
+- Note that `else` will _not_ execute if the loop ends by being terminated with a `break` statement.
+
+```py
+for n in range(2, 10):
+    for x in range(2, n):
+        # Since this code is protected with an `if` it will only execute
+        # if the number has a multiple.
+        if n % x == 0:
+          print(n, 'equals', x, '*', n // x)
+          break
+    else:
+        # This code only executes if we go thru the entire loop without matching
+        # the `if` condition.
+        print(n, 'is a prime number')
+```
+
+- `continue` statement also behaves the same as JS due to its common ancestry from C. It will break out of the current iteration of the loop and start the next iteration.
+
+### `pass` statements
+
+This literally _does nothing_.
+
+_Note: seems similar to JS's `void` keyword. I wonder what the similarity / differences between the two would be._
+
+This is commonly used as a placeholder while you're mocking out code. You can set it up and think at a higher, more abstract level.
+
+### Defining functions
+
+- The `def` keyword allows you create a new function.
+
+```py
+def fibonnacci(n):
+  """This is the docstring syntax, on the first line."""
+  a, b = 0, 1
+  while a < n:
+      print(a, end=' ')
+      a, b = b, a+b
+  print()
+
+fibonnacci(100)
+```
+
+A couple things of note about functions:
+
+- The first line of the function can be a string literal (triple `"`). This is the doc comment syntax when present.
+- Any variables declared within the function body will be _scoped to the function and override outside variables with the same names_.
+- Functions don't _have_ to return a value, by default they will return a built-in value of `None`
+- Returning a value from a function can be done with the `return` keyword.
+
+Arguments can be defined in a few syntaxes:
+
+- Default arguments. `def add(a, b=2):`.
+- Keyword arguments. Arguments can be called with either the _name_ or just with a positional valuable.
+- Catch-all arguments. `*argumentName` catches all unnamed arguments past the formally declared arguments as a list. `**argumentName` catches all the named arguments as an object.
+
+Functions can also define _how_ callers can use them, restricting certain arguments to keyword-based or position-based. Both can be used in the same function.
+
+```py
+def f(pos1, pos2, /, pos_or_keyword, *, keyword1, keyword2):
+    pass
+```
+
+Guidance from docs:
+
+```
+- Use positional-only if you want the name of the parameters to not be available to the user. This is useful when parameter names have no real meaning, if you want to enforce the order of the arguments when the function is called or if you need to take some positional parameters and arbitrary keywords.
+
+- Use keyword-only when names have meaning and the function definition is more understandable by being explicit with names or you want to prevent users relying on the position of the argument being passed.
+
+- For an API, use positional-only to prevent breaking API changes if the parameter’s name is modified in the future.
+```
+
+### Lambda expressions
+
+```py
+lambda arg: body
+```
+
+```py
+lambda a, b: a + b
+```
+
+### Function annotations (static typing)
+
+These serve as _optional type hints_ to function paramaters and are addable with the following syntax:
+
+```py
+def add(a: int, b: int) -> int:
+  return a + b
+```
+
+Types can be aliased the same way as variables, but using `TypeVar`:
+
+```py
+from typing import TypeVar
+
+T = TypeVar('T', str)
+```
+
+## Style guides
+
+Looks like [PEP 8](https://www.python.org/dev/peps/pep-0008/) is the more common and "blessed" style guide.
+
+Some notable pieces:
+
+- 4-space indentation.
+- 79-character width.
+- Use docstrings
+- Comments should be on new lines
+- Use spaces around operators and after commas, but not directly inside brackets (i.e. `(a + b)`)
+- `PascalCase` for classes and `lower_case_snake_case` for functions & methods. `self` should always be the name of the first method argument.
+
+## Data structures
+
+### List methods
+
+- `list.append(x)`: adds an item to the end of a list.
+- `list.extend(iterable)`: pushes all of the items in the iterable to the end of the list.
+- `list.insert(i, x)`: inserts `x` at the given position `i`
+- `list.remove(x)`: removes the first item in the list that matches value `x`
+- `list.pop([i])`: removes the item at index `i` in the list. `i` defaults to the last item in the list.
+- `list.clear()`: removes all items from the list
+- `list.index([i[, start[, end]])`: returns the index of the first item in the list matching `x`. Throws `ValueError` if no match is found. `start` and `end` can be used to limit the indexes of the list that are searched.
+- `list.count(x)`: returns the number of items in the list matching value `x`
+- `list.sort(*, key=None, reverse=False)`: sorts the list items in place.
+- `list.reverse()`: reverse the order of the list in place.
+- `list.copy()`: creates a shallow copy of the list.
+
+### Using lists as stacks
+
+The built-in list methods give us all of the primitives needed to use them as a _stack_ data structure.
+
+> _As a reminder, a stack is a data structure with "last in, first out" handling of items._
+
+You can add an item to the "top" of the stack using `append` (even though it's the "end" of the list). Then, you can use `pop` to get the last item.
+
+```py
+stack = [1, 2]
+
+stack.append(3)
+stack.append(4)
+stack.append(5)
+
+print(stack)
+# [1, 2, 3, 4, 5]
+
+stack.pop() # 5
+stack.pop() # 4
+stack.pop() # 3
+```
+
+### Using lists as queues
+
+> _As a reminder, a **queue** deals with items in the order of "first-in, first-out"._
+
+You _can_ also use lists as queues, but they're not going to be _as_ efficient. The reason is that operations to the beginning of the list aren't as "fast" since the items in the list have to be re-indexed.
+
+If you absolutely need a queue, then it's probably better to build one or use a prebuilt package (`dequeue`).
+
+### List comprehensions
+
+A _list comprehension_ is essentially a set of square brackets (the list) containing an expression, followed by a `for` clause. Finally, the `for` clause can optionally be followed by `for` or `if` clauses, which can add additional context.
+
+Here's a simple list comprehension to generate a list of squares from 0 - 9
+
+```py
+squares = [x ** 2 for x in range(10)]
+```
+
+However, list comprehensions can be significantly more complex:
+
+```py
+[(x, y) for x in [1, 2, 3] for y in [3, 1, 4] if x != y]
+
+# The equivalent code with for-loops
+
+l = []
+
+for x in [1, 2, 3]:
+    for y in [3, 1, 4]:
+        if x != y:
+            l.append((x, y))
+
+l # [(1, 3), (2, 1), (3, 4)]
+```
+
+### Nested list comprehensions
+
+The first portion of the list comprehension (the expression) can also be _another_ list comprehension.
+
+> **Side-note**: _I imagine this could get a little wonky to read if taken too far. But it's pretty cool how concise this can make code._
+
+```py
+matrix = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 10, 11, 12]
+]
+
+# Transpose / flip the rows and columns.
+transposed = [[row[i] for row in matrix] for i in range(4)]
+
+# This is equivalent to the following code.
+def transpose():
+    transposed = []
+
+    for i in range(4):
+        transposed.append([row[i] for row in matrix])
+
+    return transposed
+
+# If we completely undo the inner list comp we end up with this:
+def transpose():
+    transposed = []
+
+    for i in range(4):
+        transposed_row = []
+
+        for row in matrix:
+            transposed_row.append(row[i])
+
+        transposed.append(transposed_row)
+
+    return transposed
+```
+
+### The `del` statement
+
+`del` allows you to remove an item from a list _using its index_ instead of its value.
+
+```py
+a = [1, 2, 3, 4, 5, 6, 7]
+
+del a[1]
+print(a) # [1, 3, 4, 5, 6, 7]
+
+# del can also take a slice of the list
+del a[2:4]
+print(a) # [1, 2, 6, 7]
+
+del a[:]
+print(a) # []
+```
+
+### Tuples & Sequences
+
+```py
+# Tuples can be assigned with or without parentheses
+tuple = 1, 2, 3
+tuple = (1, 2, 3)
+
+# The values of a tuple can be "unpacked", similar to destructuring in JS.
+# The number of variables on the right must exactly match the number of items
+# in the tuple.
+first, second, third = tuple
+```
+
+Some notes on tuples:
+
+- tuples themselves are _immutable_. However, they can contain mutable objects.
+
+### Sets
+
+A _set_ is an unordered collection of values where each value is guaranteed to appear only 1x within the set.
+
+Sets can be created in the following ways:
+
+```py
+s = {"mercury", "venus", "earth", "mars", "jupiter"}
+s = set(["mercury", "venus", "earth", "mars", "jupiter"])
+```
+
+Sets allow some easy methods for testing existence of a value as well as eliminating duplicate values:
+
+```py
+arr_1 = [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1]
+arr_2 = [1, 2, 3, 10]
+
+a = set(arr_1)
+b = set(arr_2)
+
+# test for existence of a value
+5 in a
+
+# unique values in arr_1
+a
+
+# values in arr_1 but not in arr_2 (difference)
+a - b
+
+# combination of all values in a OR b OR both (union)
+a | b
+
+# only the values in BOTH a AND b (intersection)
+a & b
+
+# only the values in a OR b, but NOT both (symmetrical)
+a ^ b
+```
+
+Set comprehensions can also be created, similar to list comprehensions
+
+```py
+a = {x for x in 'abracadabra' if x not in 'abc'} # {'r', 'd'}
+```
+
+### Dictionaries
+
+This is a key-value store, keys can only be immutable types (strings and numbers). Tuples can be a key as long as _they_ do not contain any mutable types as well.
+
+```py
+pets = {'moses': 1, 'bubbles': 2, 'sadie': 3}
+
+pets['moses'] # 1
+
+del pets['sadie']
+```
+
+You can also build a dictionary from key-value tuples using `dict`, dict comprehensions, or simple named arguments (for simple keys):
+
+```py
+# tuples
+dict([('moses', 1), ('bubbles', 2), ('sadie', 3)])
+
+# dict comprehension
+{x: x**2 for x in (2, 4, 6)} # { 2: 4, 4: 16, 6: 36 }
+
+# simple named args
+dict(moses=1, bubbles=2, sadie=3)
+```
+
+### Looping techniques
+
+You can loop thru an object and get the key _and_ value simultaneously using the `.items()` method.
+
+```py
+pets = {'moses': 1, 'bubbles': 2, 'sadie': 3}
+
+for name, pet_id in pets.items():
+    print(name, ': ', pet_id)
+```
+
+In a sequence you can get the index _and_ value simultaneously using the built-in `enumerate` function.
+
+```py
+nums = [1, 2, 3, 4, 5, 6]
+
+for i, v in enumerate(nums):
+    print(i, ': ', v)
+
+# 0: 1
+# 1: 2
+# 2: 3
+# ...
+```
+
+### More on conditional operators
+
+- You can use the keywords `and` & `or` to chain conditionals together. Expressions are evaluated left-to-right, and evaluation stops as soon as the condition is determined (i.e. if the first one is false in `A and B and C`, `B` and `C` won't be evaluated).
+- If you do assignment _inside_ the condition you have to use `:=` instead of `=`.

--- a/apps/website-sv/src/content/notes/redis-cheatsheet.mdx
+++ b/apps/website-sv/src/content/notes/redis-cheatsheet.mdx
@@ -1,0 +1,31 @@
+---
+title: Redis cheatsheet
+date: 2021-01-27T00:00:00.000Z
+---
+
+## Installation
+
+If you're on a Mac (usually the case for me), you can install Redis via Homebrew:
+
+```bash
+brew update
+brew install redis
+```
+
+## Starting the server
+
+You can start the server in a background process with `brew services`:
+
+```bash
+brew services start redis
+```
+
+```bash
+brew services stop redis
+```
+
+Alternatively, if you don't want to run Redis in the background, you can use the `redis-server` to start Redis:
+
+```bash
+redis-server /usr/local/etc/redis.conf
+```

--- a/apps/website-sv/src/content/notes/soap.mdx
+++ b/apps/website-sv/src/content/notes/soap.mdx
@@ -1,0 +1,11 @@
+---
+title: SOAP APIs
+date: 2021-01-07T00:00:00.000Z
+tags:
+  - back-end
+  - http
+---
+
+## What is SOAP?
+
+At a high-level, SOAP (Simple Object Access Protocol) is a _protocol_ for accessing resources on the internet. Whereas REST—an HTTP protocol more commonly used today—deals with JSON requests and responses, SOAP relies on **XML** for defining request and response objects.

--- a/apps/website-sv/src/content/notes/when-to-build-from-scratch-vs-using-a-library.mdx
+++ b/apps/website-sv/src/content/notes/when-to-build-from-scratch-vs-using-a-library.mdx
@@ -1,0 +1,7 @@
+---
+title: When to build from scratch versus using a library
+date: 2020-02-02T00:00:00.000Z
+tags:
+  - programming
+  - philosophy
+---

--- a/apps/website-sv/src/content/writing/2022-year-in-review.md
+++ b/apps/website-sv/src/content/writing/2022-year-in-review.md
@@ -1,0 +1,49 @@
+---
+title: '2022 year in review'
+date: 2023-01-03
+tags:
+  - career
+  - updates
+---
+
+Modern life is so fast-paced. Years can easily soar past if we’re not careful, and this time between Christmas and New Years is a perfect opportunity to reflect on all the significant things that have happened over the past year.
+
+Here’s some of my reflections on what happened in 2022.
+
+# 👶🏻 Baby
+
+In March my wife and I welcomed our son to our family. Becoming a dad and watching this little boy grow up (so fast!) has been awesome.
+
+I’m grateful to Panther Labs for offering a generous parental leave that allowed me to spend the first few months of my son’s life bonding with him and my wife.
+
+It’s remarkable how much my son has grown throughout this year. We’ve gotten to watch him go from a little newborn to crawling and stumbling around the house. I’m so excited to see him grow up even more in 2023.
+
+# ⬆️ Promotion to principal engineer
+
+Sometime in May (while I was out on parental leave) I got a call from my employer. Turns out I had gotten promoted during the regular performance review cycle!
+
+Operating as a principal engineer at Panther taught me a ton—notably about having influence without institutional authority, setting technical direction, mentorship, and technical leadership.
+
+# 🏠 Purchasing a house
+
+In early August my wife and I closed on our first house! It’s been fun doing some light home improvement projects, settling in, and not planning another stressful move for a long while.
+
+# 🌱 Being a (temporary) manager
+
+In late October I stepped in as an interim manager at Panther while we backfilled an open manager role on my team. Being an interim manager required me to change my entire job description overnight—I wasn’t 50% individual contributor (IC) and 50% manager, I was 100% manager for a limited amount of time.
+
+I enjoyed some aspects of the job and disliked others. Some notable highlights were tightly collaborating with my PM & designer, and getting to know my teammates much better.
+
+I was told that I did an ok job and that I could probably continue down the management path if I wanted to. However, my stint in management was also a confirmation of my desire to stay on the IC track for the foreseeable future.
+
+# 💼 New job
+
+Just a few weeks ago, I started a new job at [Sublime Security](https://sublimesecurity.com/)! I’m back as an IC, working on their frontend experiences. I’m terribly excited about this opportunity and looking forward to diving deep into their frontend stack as I enter 2023.
+
+# 🗓️ What’s next?
+
+2022 was a huge year, full of massive milestones. I don’t know what 2023 will hold, and I try not to forecast too far ahead!
+
+That said, I’m planning on watching my son grow up even more (I love working from home), settling more into our house, and building some amazing stuff at Sublime.
+
+Here’s to 2022 🥂

--- a/apps/website-sv/src/content/writing/5-myths-about-the-post-bootcamp-job-search.md
+++ b/apps/website-sv/src/content/writing/5-myths-about-the-post-bootcamp-job-search.md
@@ -1,0 +1,58 @@
+---
+title: 5 Myths About The Post-Bootcamp Job Search
+description: Here’s 5 common misconceptions that could be holding you back from your first development job.
+date: 2017-08-14
+image:
+  url: 'blog-img-man-at-desk.jpg'
+  alt: Man working at desk, taking notes
+tags:
+  - career
+---
+
+These days it seems like everybody is trying to break into tech. I was just there 2 months ago: and if you had told me that my job search would only be 6 weeks, I would have just written you off as wildly optimistic.
+
+I’ve also seen a lot of other bootcampers struggle to find their first job, largely because they have huge misconceptions about the development landscape. As a result it takes them months to find something or they settle for way less than market rate. I used to believe a lot of these myths, and I was fortunate enough to have someone snap me out of it right as I started my job search.
+
+Without further ado, here’s 5 common misconceptions that could be holding you back from your first development job.
+
+## Myth #1: You can’t provide real value if you are at an entry level.
+
+You have the capacity to provide real, monetary value to companies, even with 3–6 months of experience. The fact is that you are paid to solve problems and provide business value to your employer, not just to learn or gain experience. And companies like to hire people that can solve their problems.
+
+If you focus on how you can provide value to a company instead of what you can get out of it you will portray yourself as a more savvy & attractive candidate than someone who doesn’t. Show that you’re capable of seeing real problems a business may be facing and make sure you propose solutions as you go through the interview process.
+
+## Myth #2: Now that you’re done with bootcamp, you can stop learning to code and focus on finding a job.
+
+This couldn’t be farther from the truth. In fact, I’d argue that this is one of the biggest mistakes that I saw a lot of my fellow bootcamp grads make.
+
+If you haven’t written a line of code since you graduated, get up and make something today. And I don’t mean follow a tutorial or solve a couple CodeWars kata. Of course, when you finish your bootcamp you’ll end up spending a little more time doing non-coding things, but don’t forget to make a project here or there — it keeps your chops up, shows that you have passion and self-motivation, and allows you to feed that passion that first got you into programming.
+
+The tech world moves at a breakneck pace, and you want to be up-to-date. Being able to talk shop about the major frameworks/developments in your language of choice shows that you have passion, self-motivation, and the intellectual capacity to understand their nuances.
+
+For example, if you were a frontend dev (or targeting frontend positions), you would want to know about the differences between React/Vue/Angular or a bit about ES5 vs ES2015+.
+
+## Myth #3: The projects you did in dev bootcamp will speak for themselves.
+
+This ties into the last point.
+
+You probably made 1–4 “original” projects while you were in dev bootcamp. You put the code up on GitHub where everyone can see what an amazing job you did. That’s awesome. You’re off to great start!
+
+The thing is, bootcamps have varying degrees of hand-holding with their projects. Maybe you worked in a group with other fellow students. Maybe you worked alone, but you had a mentor or TA help you when you got stuck. Maybe you did most of the work yourself with minimal help. The point is, you have to continue to work on stuff after you graduate.
+
+You could do anything! Everyone has a friend or relative that’s looking for either a website or needs a website facelift. Tons of nonprofits/small businesses would be willing to take chances on young developers since they can’t afford the experienced ones. Open Source projects are always in desperate need of contributors, and there’s entire sites devoted to making it easy for newbies to start contributing.
+
+If all those fail (which I find hard to believe), build another personal project. Redesign your portfolio. Make that open source package you thought would be fun. The more you have to show your competence, the better— especially when you don’t have years of experience in your favor.
+
+## Myth #4: You learned all of the fundamentals in your programming language of choice.
+
+Whatever language(s) that you learned are extremely nuanced. Chances are it’s been around for a while, and the community around that language has its share of best practices/debates.
+
+Make it your goal to learn some of the nuances/gotchas of whatever language you plan to be interviewing in—it will really set you apart from other bootcampers that only learned what their curriculum taught.
+
+Of course it’s also worth noting that not all bootcamps are equal in this regard. Some really dive into language fundamentals while others gloss over. The responsibility becoming a master of your craft is yours alone.
+
+## Myth #5: You just need to get your job, then everything will settle down.
+
+Have a bigger vision than your first developer job. Keep building side projects, learning new technologies, and networking your butt off. If you ever feel like you’re plateauing, find a way to move forward or find someone to help you.
+
+This is your career we’re talking about, not just your first developer job. Take ownership of your personal brand and your professional development and continue to build both of them while you work at your first job. That way you’ll be an expert in no time, and the next time you have to do a job search you’ll have companies fighting to hire you.

--- a/apps/website-sv/src/content/writing/accessible-icon-buttons.md
+++ b/apps/website-sv/src/content/writing/accessible-icon-buttons.md
@@ -1,0 +1,254 @@
+---
+title: Accessible icon buttons
+date: 2020-09-02
+tags:
+  - front-end
+  - accessibility
+---
+
+Accessibility matters. Especially in today's world where we perform essential aspects of our life online. Your bank, social media, email—all of it probably uses a web at some point or another.
+
+I'm not gonna dive too much into [the business case for accessibility](https://www.w3.org/WAI/business-case) in this post, that's for another time. But suffice it to say that web accessibility is essential for any business operating a website. Two immediate reasons to care are the [legal risk](https://www.w3.org/WAI/business-case/#minimize-legal-risk) of inaccessible products and that [~15% of the population](https://www.worldbank.org/en/topic/disability#1) is considered to have some type of long-term disability.
+
+Icon buttons are a fairly common UI pattern in web apps. It's funny hearing about young kids seeing a floppy disk and exclaiming "You 3d-printed a save icon!" But it certainly illustrates the fact that we're acquainted with icon buttons and the actions that they represent.
+
+But what about people that can't see? How do they interact with icon buttons?
+
+Here's a couple principles for building icon buttons that everyone can use, whether or not they can see them.
+
+## Icon buttons should be _buttons_
+
+First things first, icon buttons should be a `button` element under the hood. Most screen readers rely on good HTML markup to properly announce what types of interactions are possible when an element is focused.
+
+Attaching `onclick` to a `div` may work if you're pointing and clicking in the app, but it makes interacting with the icon button impossible if you're on a screen reader. And while you can add other attributes to make the `div` accessible (like `aria-role`, `aria-label`, `tabindex`), it's not simple. And you're still not guaranteed it'll work properly in all screen readers 😭
+
+**My recommendation: just use a `button` under the hood.**
+
+## The problem: not enough information
+
+Before we go too far into how to make **good icon buttons**, let's look at why it's so common to see inaccessible icon buttons in today's web applications.
+
+Consider the follow non-icon button:
+
+```html
+<button>Click me!</button>
+```
+
+When focused on this button in a screen reader, I get the following message (this is using VoiceOver on macOS):
+
+```
+Click me!, button
+```
+
+The screen reader automatically picks up the **role** of the focused element (a "button") as well as the **label** on the button ("Click me!"). This is the same information that a sighted user has—they'll know it's a **button** from the way it's styled, and they'll know the **label** from the text directly inside the button.
+
+However, when we have an icon-only button, we end up with a different screen reader experience. Consider the following markup:
+
+```html
+<button>
+	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<!-- "refresh" icon -->
+	</svg>
+</button>
+```
+
+A user that can see the button knows it's a "refresh" action, and based on their experiences with other applications they know that if they click this button, it'll refresh some data.
+
+But what happens if we focus the button in a screen reader?
+
+This is all that we get:
+
+```
+button
+```
+
+If we're only using a screen reader to interact with our button, we have no clue **what** it does. For all we know, this button could refresh our data, delete it, or do something entirely different! And that's not a great experience 😱
+
+While we could always alter our designs to include **both** icons and text, sometimes that's not possible for a given design system. After all, a button with a simple icon has a nice, clean look.
+
+Fortunately there's a few ways that we can make something usable for **both** our sighted **and** our screen reader users.
+
+## Provide an invisible label for the screen reader
+
+The most important thing that we can do to make our icon button accessible is provide a label that's only for the screen reader. If you're looking at the button, it'll be exactly like the inaccessible version, but if you focus the icon in a screen reader you'll get some text telling you what this button does.
+
+There's 2 main ways to add this invisible button label.
+
+### Option #1: use "screen reader only" text
+
+The first way that we can provide text for the screen reader is by using **screen reader only** text.
+
+Essentially, we add text inside the button as if it had the icon **and** text. Then, we use some CSS magic to hide the text from sight.
+
+Here's the CSS that I usually use to make an HTML element invisible from sight, yet accessible to screen readers. It hides the content from sight and makes sure that the invisible content doesn't mess up any layouts either 🙌
+
+```css
+.visually-hidden {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}
+```
+
+_Note: if you're using [Bootstrap](https://getbootstrap.com/) you can use the `.sr-only` CSS class to create visually hidden content._
+
+It's important to note that we're **not** using `display: none` or `visibility: hidden` in our CSS. The reason for this is that applying either of these **removes** the element from the accessible DOM. Adding either one makes it impossible for a screen reader to "see" the content and read it out loud.
+
+Once you've got a `.visually-hidden` class written up, making our icon button accessible looks like this:
+
+```html
+<button>
+	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<!-- "refresh" icon -->
+	</svg>
+
+	<span class="visually-hidden">Refresh</span>
+</button>
+```
+
+All we need to add is that `span` with `Refresh` inside of it. Applying the `.visually-hidden` class makes the text invisible, so it looks exactly like the icon button from before.
+
+Finally, when we focus the button in a screen reader, we get the following:
+
+```
+Refresh, button
+```
+
+### Option #2: use `aria-label`
+
+An alternative approach to using a `.visually-hidden` CSS class is leveraging an `aria-label` on the `button` element itself. This overrides the default "label" that the screen reader would've read with the `aria-label` value:
+
+```html
+<button aria-label="Refresh">
+	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<!-- "refresh" icon -->
+	</svg>
+</button>
+```
+
+This achieves the exact same screen reader output as the example with visually hidden text (at least in VoiceOver for macOS it does).
+
+## Hide the icon from the screen reader
+
+Another common practice when writing icon buttons is to add `aria-hidden="true"` to the icon itself. While I haven't any issues with VoiceOver for macOS reading the contents of SVGs, I think there's some screen readers that **do** announce the icon inside.
+
+```html
+<button>
+	<svg
+		aria-hidden="true"
+		xmlns="http://www.w3.org/2000/svg"
+		height="24"
+		viewBox="0 0 24 24"
+		width="24"
+	>
+		<!-- "refresh" icon -->
+	</svg>
+
+	<span class="visually-hidden">Refresh</span>
+</button>
+```
+
+`aria-hidden="true"` hides the icon from the screen reader—the inverse of how `.visually-hidden` made the text invisible to sighted users.
+
+## 🔥 Hot tip: require labels in icon button components
+
+Chances are you're using a front-end framework to build your web applications.
+
+At the same time, you car about creating accessible buttons—you don't want to alienate a large amount of potential customers by giving them something that isn't usable.
+
+One of the cool techniques I've used in a number of codebases is leveraging **components** to encourage accessible patterns. We can make accessibility the "default state" just by the way we structure our component APIs.
+
+**Strong, accessible components make it easy to do the "right" thing" and difficult to do the "wrong" thing.**
+
+For example, here's a way we could build an accessible icon button in React and TypeScript. I'm using the `Fab` nomenclature (**F**loating **A**ction **B**utton) from [Google's Material Design](https://material.io/components/buttons-floating-action-button).
+
+```tsx
+interface FabProps {
+	// Accessibility-only icon label
+	label: string;
+	// Markup for the icon itself
+	children: ReactNode;
+}
+
+const Fab = (props: FabProps) => {
+	return (
+		<button {...props} aria-label={props.label} className="fab">
+			{props.children}
+		</button>
+	);
+};
+```
+
+You'll notice in `FabProps` that `label` is **required** on the component. If it were optional we would have typed it with `label?: string`.
+
+This means that if you forget to provide a `label`, you'll get a compile-time error. You'll be **forced** to put _something_ (anything!) as `label`, guaranteeing that screen reader users get an equally usable experience.
+
+I've used this approach quite a bit and it works great most of the time. Whenever you forget to add an accessible label, that compiler error is usually enough to remind you to go add screen reader text.
+
+That said, there's still one edge case where we can sneak around the type system and make an inaccessible icon button:
+
+```tsx
+<Fab label="">
+	<svg>{/* svg content */}</svg>
+</Fab>
+```
+
+If we provide an empty label, we get around the type error, but we've still made an icon button that doesn't work on screen readers 😱
+
+This case can be guarded against with thorough pull request reviews as well as a team that's educated on accessible HTML. If you're used to seeing `label` with a value, seeing `label=""` is a huge red flag!
+
+But if you want to protect against this case **in the code itself**, you'll need to do some type of run-time checking. For instance, we could do augment our `Fab` to guard against any `label` prop that's empty.
+
+```tsx
+const Fab = (props: FabProps) => {
+	// Only have the error if NODE_ENV === 'development' and label is empty.
+	// This global __DEV__ variable assumes a setup like
+	// https://github.com/formium/tsdx#advanced-babel-plugin-dev-expressions
+	if (__DEV__ && !props.label) {
+		// If you want to be more aggressive with the error, you can actually
+		// `throw` an error here.
+		console.error(`
+      You have not provided an accessible label for this icon button. 
+      Please add some content to the "label" prop to remove this error.
+
+      For further reading about providing accessible labels, please refer to 
+      https://dequeuniversity.com/rules/axe/3.2/button-name.
+    `);
+	}
+
+	return (
+		<button {...props} aria-label={props.label} className="fab">
+			{props.children}
+		</button>
+	);
+};
+```
+
+This adds a **dev-only error** so that using the component with `label=""` creates a warning for the developer, but doesn't crash the app or anything. We've also made the error message educational and actionable—you know exactly what needs to be done to get rid of the message.
+
+As an added benefit `console.error` is enough to fail unit tests (if you're using Jest, at least)!
+
+> **Note:** _If you're not using TypeScript this approach provides a similar level of
+> developer protection against missing `label` props. Depending on your tooling
+> you might also be able to strip out the dev warnings for your production build
+> as well (that way you don't bloat your JS bundles)._
+
+## tl;dr
+
+Icon buttons should have an accessible label so screen readers can interact with them. The easiest ways to do this are visually hidden text or an `aria-label` attribute.
+
+---
+
+## Additional resources
+
+- [Accessible Icon Buttons](https://www.sarasoueidan.com/blog/accessible-icon-buttons/) by Sara Soueidan.
+- [Accessible Icon Buttons](https://egghead.io/lessons/aria-accessible-icon-buttons) Egghead course taught by [Marcy Sutton](https://twitter.com/marcysutton)
+- [Deque University "button name" rule](https://dequeuniversity.com/rules/axe/3.2/button-name).
+  If you're using [axe accessibility audit](https://www.deque.com/axe/) to check your markup you'll be linked to this page every time you have inaccessible button text.

--- a/apps/website-sv/src/content/writing/adding-pipelines-to-javascript.md
+++ b/apps/website-sv/src/content/writing/adding-pipelines-to-javascript.md
@@ -1,0 +1,13 @@
+---
+title: 'Adding pipelines to JavaScript'
+description: In this article I examine one of ECMAScript's exciting new proposals which adds a pipeline operator to JavaScript.
+
+date: 2018-11-19
+publisher: LogRocket
+link: https://blog.logrocket.com/adding-pipelines-to-javascript-f79ae7311574/
+tags:
+  - functional-programming
+  - javascript
+---
+
+In this article I examine one of ECMAScript's exciting new proposals which adds a pipeline operator to JavaScript. Pipelines offer a clean method of composing functions, and it's cool to play around with them in JavaScript.

--- a/apps/website-sv/src/content/writing/april-may-2022-update.md
+++ b/apps/website-sv/src/content/writing/april-may-2022-update.md
@@ -1,0 +1,26 @@
+---
+title: April/May 2022 update
+date: 2022-06-03
+tags:
+  - updates
+  - writing
+---
+
+April & May have been quite busy, but figured I'd drop a quick update on what I've been up to.
+
+## Full-time parenting 🐣
+
+I spent all of April & May on parental leave. And boy, did we need it!
+
+Being a parent is _not_ easy, but it is ✨ _so_ ✨ rewarding. I'm very grateful to my employer for these 10 weeks of time to spend caring for my wife and son. I don't know what we would have done without it.
+
+## Principal engineer! 🧑‍💻
+
+I did get one work call while on leave. I've been promoted from Staff Engineer to Principal Engineer at [Panther](https://panther.com/)! I'm looking forward to exploring what this means in practice as I return from leave and continuing to build delightful frontend security workflows.
+
+## Misc. updates 🤓
+
+- Been playing **much more** with [Remix](https://remix.run/) and I can firmly say I'm excited about it.
+- I rewrote this website in Remix, and saw things become much simpler as a result! Win-win!
+- Been reading [Designing Data Intensive Applications](https://www.amazon.com/Designing-Data-Intensive-Applications-Reliable-Maintainable/dp/1449373321) by Martin Kleppmann. While I'm more of a frontend specialist, I do regularly find myself working on distributed systems and collaborating with backend engineers. It's been a fascinating, in-depth look into what distributed systems have to deal with.
+- It's been an unusually wet spring in the PNW, so I haven't got to spend as much time outdoors as I expected. But I'm excited for the summer months when we'll be able to spend some time outdoors!

--- a/apps/website-sv/src/content/writing/arrange-act-assert.md
+++ b/apps/website-sv/src/content/writing/arrange-act-assert.md
@@ -1,0 +1,40 @@
+---
+title: Arrange, Act, Assert
+date: 2020-10-17T19:29:32.251Z
+tags:
+  - testing
+---
+
+One pattern I find helpful for writing automated tests is "Arrange, Act, Assert". Using this pattern, we can break up every test into three parts.
+
+## 1. Arrange
+
+First, you set up anything in the test environment that your code needs.
+
+Some examples of this include creating mock functions, seeding a database with test data, resetting the date/time, and creating global variables.
+
+The goal during this step is to create a controlled, predictable environment for your test to run in.
+
+> _**This phase is optional.** Some tests don't require you to set up the test environment and that's totally fine._
+
+## 2. Act
+
+This is where we actually run the code we want to test.
+
+If you're writing tests for a React component, render the component. If you're writing tests for a function, call the function and pass in some arguments.
+
+## 3. Assert
+
+Finally, the "Assert" step is where you check your code. You'll make sure that whatever you ran in the "Act" step did what it should have done.
+
+If you're using Jest or Chai this would be where you call `expect` with something like `toEqual`.
+
+Most assertions follow the format of `expect(result).toEqual(expectedOutput)` (This is Jest's syntax).
+
+> _Some people will tell you that you should only have 1 assertion per test. I don't agree with this, I think it's a little dogmatic and restraining. The number of assertions that you need may vary from test to test._
+
+## Conclusion
+
+I've found this pattern extremely helpful when writing my own tests and when teaching software testing. I think the "AAA" initials make it easier to remember and breaking out the tests into 3 separate phases makes it easy to focus on one thing at a time.
+
+As you write more and more tests throughout your career, you might find that you're thinking less about which step of the test you're in. You might find yourself cycling between all three multiple times on a single test. That's ok! This approach isn't dogma or "The One True Way", it's just a helpful way to think about the parts of an automated test.

--- a/apps/website-sv/src/content/writing/audit-all-npm-dependencies.md
+++ b/apps/website-sv/src/content/writing/audit-all-npm-dependencies.md
@@ -1,0 +1,99 @@
+---
+title: Audit all NPM dependencies in a project using this bash script
+date: 2020-07-02
+draft: false
+tags:
+  - bash
+  - automation
+  - npm
+---
+
+## Intro
+
+It's no secret that the JavaScript ecosystem is built on the backbone of OSS. Need a fully-featured front-end framework with all the batteries included? Only an `npm install` away. Need to parse a URL query string? `npm install querystring`. Want some padding before the start of your string? `leftpad` to the rescue! Chances are, any substantially large project built in JavaScript will have _some_ OSS dependencies, if not _many_.
+
+_Note: this isn't a post about when you should install an NPM package vs when you should write some custom code. That is certainly a long, nuanced discussion that merits its own post!_
+
+However, when you start diving into the _legal_ aspects of OSS, you'll quickly find that there are _**a bunch of different open source licenses**_. MIT, Apache-2.0, GPL, MPL-2.0, WTFPL, the list can go on and on.
+
+The differences between these licenses can be nuanced and difficult to understand. 😭 But as an engineer working with open source software, it's important that we know the implications of the license that we're using. But that's a different post altogether! 😅
+
+Even if you're being diligent to only use licenses that you have permission to use, it's still likely that your company's legal team is going to want to check this at some point. And that makes sense, it's their job to check this type stuff and make sure that the company isn't headed towards legal problems from software licensing issues.
+
+This exact situation has happened to me a few times now over the course of a project I've been working on for one of our clients. As a team lead, these types of requests often fall on my plate. The first time I went through every single repository for the project and started copying the licenses (`yarn licenses list`) into a document.
+
+Talk about tedious. 😱
+
+But then I had a thought.
+
+Isn't this what writing code is for—getting computers to automate away all the boring, repetitive tasks, so that we can focus on more important things?
+
+So here's my script for automating away this problem!
+
+## Prerequisites to run this script
+
+I know this script isn't bullet-proof—it's something I've been using in my personal development to solve a problem. As a result, it's somewhat tailored to my own workflow.
+
+So before we get to the code, a couple disclaimers.
+
+**This script is Zsh-specific.** I use Zsh along with the fantastic [git aliases](https://github.com/ohmyzsh/ohmyzsh/wiki/Cheatsheet#git) that come built-in with Oh My Zsh. As a result some of the git operations (like `ggl` for `git pull origin` and `gco` for `git checkout`) might not work if you run this in regular ol' Bash.
+
+_I might circle back around and update this to be completely Bash someday, but it's not really that high on my priority list. If you want to submit a PR to this article to update the snippet I'm more than happy to merge it!_
+
+**This script is built assuming the following directory structure.** Since I'm currently working as a consultant and it's possible that we might have code for different clients on the same computer, I use the following directory structure on my work machine.
+
+```bash
+work
+└─ client-a
+│     └─  repo-1
+│     └─  repo-2
+└─ client-b
+│     └─  repo-1
+```
+
+This snippet is built to run inside of the `client-a` repository, and would provide you with all the licenses used in both `repo-1` and `repo-2` as a single text file (`licenses.txt`).
+
+## Enough already, show me the code!
+
+Without further ado, here's the code:
+
+```bash
+# We go thru the directories and update the git branches in a SEPARATE
+# loop so that we can easily see whether there were any issues with updating
+# the master branch (for example, you have changed files on a branch that
+# would be overwritten by merging master).
+for d in */;
+# $d is the directory name
+do
+  SEPARATOR="\n--------------------\n"
+  echo "$SEPARATOR $d $SEPARATOR";
+  # Putting this line in parentheses makes the terminal cd out of the
+  # directory after all of the commands in the parentheses have exited.
+  (cd $d && gco master && ggl);
+done;
+
+# Clean out the file if it was preexisting
+rm licenses-2020-07-02.txt;
+# Create a new blank file
+touch licenses-2020-07-02.txt;
+
+# Loop thru every directory in the folder containing all of the repos.
+# This 2nd loop is where we are going to aggregate all of the licenses into
+# the licenses file.
+for d in */;
+# $d is the directory name
+do
+  HEADING="\n-------------------------\n $d \n-------------------------\n";
+
+  # Print out a header with the repo name,
+  # append (>>) this to the licenses file.
+  echo $HEADING >> licenses-2020-07-02.txt;
+
+  # Go into the directory and print the licenses
+  # append them to the licenses file as well.
+  (cd $d && yarn licenses list) >> licenses-2020-07-02.txt;
+  echo "✅ Audited licenses for '$d'."
+done;
+```
+
+If this code was useful to you and helped you solve real-world problems, I'd love to hear about it! Feel free to reach out to me on my [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (reference this article so I know it's not spam!). Thanks for reading!

--- a/apps/website-sv/src/content/writing/clean-console-using-chrome-devtools-to-stop-logging-to-the-console.md
+++ b/apps/website-sv/src/content/writing/clean-console-using-chrome-devtools-to-stop-logging-to-the-console.md
@@ -1,0 +1,87 @@
+---
+title: Clean Console
+description: Using Chrome DevTools to Inspect JSON Responses from API Requests
+date: 2018-02-01
+image:
+  url: 'tools.jpg'
+  alt: Tools at a workdesk
+---
+
+I’ve been fortunate to instruct and work with many people that are beginning to code through the very same bootcamp I attended about a year and a half ago ([Thinkful](https://www.thinkful.com/) &mdash; yes this is a shameless plug 😜 ). Most recently I’ve been doing a series of workshops on Chrome Devtools, where I teach common parts of Chrome DevTools that many front end developers are using daily. One of the most common inefficiencies I’ve noticed is using `console.log` to preview JSON responses from an API.
+
+I didn't learn how to use Chrome DevTools until I got on my first gig. I knew how to do the basics &mdash; preview CSS changes, change HTML, basically a bit of the stuff inside the `Elements` tab.
+
+I've also heard similar stories from some of my colleagues at my current job &mdash; debugging & developer tools aren't usually learned until _after_ people get out on their first gig. One reason is that 3–6 months is a short time to learn how to program, much less learn how to use developer tools well (but I digress…maybe that’s another blog post).
+
+My most recent workshop focused on the Chrome DevTools "Network" tab: how to analyze your load time & other "productivity hacks" I've picked up.
+
+## The Problem: Log, Log, Everywhere
+
+One of the earlier lessons in the process of learning web development is learning about fetching data via AJAX. Most apps that goes beyond triviality or need to respond to data dynamically are gonna fetch some JSON from an API, and then operate on that JSON.
+
+Many times, I would find myself doing something like this in my source code so that I could preview the JSON response.
+
+```javascript
+fetch('https://jsonplaceholder.typicode.com/posts')
+	.then((res) => res.json())
+	.then((json) => {
+		console.log(json); // to see what the response was
+		// code operate on the JSON goes here
+	});
+```
+
+To preview my JSON, I would either scatter console.log all over my codebase and dig through the browser console window to find my JSON, or I would copy-paste the endpoint into Postman or a cURL request. All of these work, but **what if there was a faster way to debug JSON responses in the browser?**
+
+---
+
+## Chrome DevTools To the Rescue!
+
+Thanks to Chrome DevTools, we can preview our JSON _without touching our source code_ (read: higher productivity & a smaller chance that you accidentally forget to delete a `console.log`).
+
+### 1. Open the Network Tab
+
+I’m going to demonstrate all of this on one of my own apps, called [Horizon](https://benjaminj6.github.io/horizon). It's essentially a sunset tracker, pulling data from https://sunrise-sunset.org/. You're welcome to follow along or use any app of your choice, provided it sends JSON over the internet.
+
+First, since we're gonna be debugging via the Network Tab, we'll want to open that up. Once you've got it open, you'll see something like this.
+
+![network tab open](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120282/network_tab_open_xwckl5.png)
+
+Great! Now we're all set to start our debugging.
+
+### 2. Filter by `XHR`
+
+While my sample app may not have a ton of requests, many apps can contain 100+ requests on initial page load, making it a little more difficult to find the specific AJAX request we're looking for.
+
+Fortunately, Chrome DevTools lets us filter by response type. You'll see all of the options available to you near the top bar. Select **`XHR`** (this stands for **X**ml**H**ttp**R**equest), which contains all JSON data pulled into the app via `fetch` (or `$.ajax`, `axios`, or whatever way you're using to grab your data).
+
+With the response filtered, your Network Tab should look like this:
+
+![network tab filtered](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120282/devtools_filter_xhr_bfh1x5.png)
+
+That's really slick! Now we only have to parse through a few requests to find what we're looking for.
+
+### 3. Inspect & Preview...Voila!
+
+Find the request that you're interested in. Click on the request and you should see a menu like this pop up.
+
+![network request inspect](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120283/devtools_view_request_rvmirk.png)
+
+The final step is for us to select that `Preview` tab. Once selected, you should see something like this.
+
+![preview pane with json](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120282/devtools_preview_json_re3xgb.png)
+
+There's our JSON! We've successfully found it _without touching our source code_. This means we can use this method of debugging _anywhere we can use Chrome DevTools_ &mdash; including debugging sites in production with minified JavaScript.
+
+---
+
+## Conclusion
+
+If you’re a seasoned pro and read all the way to the end, you might be thinking, “I’ve known this for years, people have really never learned this?”
+
+When I first discovered this method of debugging network requests, I felt like I had just been given superpowers. I’m grateful for the developers in my career that taught me how to use tools and increase my productivity. A well-placed `console.log` can be an extremely effective tool, but scattering it all over source code felt much like the whole "Maslow's Hammer" dilemma:
+
+> I suppose it is tempting, if the only tool you have is a hammer, to treat everything as if it were a nail.
+>
+> — Abraham Maslow, 1966
+
+As always, if you read this post and enjoyed it, I'd love to know! Shoot me a tweet on my [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/).

--- a/apps/website-sv/src/content/writing/conventional-commits.md
+++ b/apps/website-sv/src/content/writing/conventional-commits.md
@@ -1,0 +1,63 @@
+---
+title: Conventional Commits
+date: 2022-11-23
+tags:
+  - teamwork
+  - software-engineering
+  - cheat-sheets
+---
+
+## Why?
+
+Conventional commits are useful for a number of reasons, but the most useful to me are:
+
+1. You can succinctly note the nature of the change you are making in each commit.
+2. You can auto-generate semantic versions based on the prefix + breaking change notation.
+
+The first is useful regardless of whether other engineers follow conventional commit format, while the second requires you to set up automation and enforce all commits to be in the conventional format.
+
+I find myself using the conventional commit prefixes fairly frequently, and am always looking them up, so that's why I wrote this cheat sheet. 😎
+
+Here's some of the most common ones.
+
+## Commit prefixes
+
+| prefix      | meaning                                                       |
+| ----------- | ------------------------------------------------------------- |
+| `feat:`     | A new product feature                                         |
+| `fix:`      | Fixing a bug                                                  |
+| `refactor:` | Refactoring code, no new features                             |
+| `docs:`     | Updating documentation                                        |
+| `style:`    | Formatting changes to code only                               |
+| `test:`     | Changing / fixing tests                                       |
+| `ci:`       | Changes to CI builds                                          |
+| `build:`    | Changes to build system, deployment, etc                      |
+| `chore:`    | Cleanup, renaming, organizing, etc. Catch-all for small tasks |
+
+## Conventional commit format
+
+In general, conventional commits use the following structure:
+
+```
+{prefix}: {description}
+
+fix: reorder modal z-index
+```
+
+Optionally, you can include a "scope" of your change:
+
+```
+{prefix}({scope}): {description}
+fix(homepage): reorder modal z-index
+```
+
+Finally, if your commit introduces a breaking change, you can include an exclamation point:
+
+```
+{prefix}!: {description}
+feat!: new routing API
+```
+
+## Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)

--- a/apps/website-sv/src/content/writing/copy-to-clipboard.md
+++ b/apps/website-sv/src/content/writing/copy-to-clipboard.md
@@ -1,0 +1,81 @@
+---
+title: copyToClipboard
+subtitle: Function that copies an input value to the system clipboard
+date: 2020-12-22
+tags:
+  - typescript
+  - recipes
+---
+
+```ts
+export const copyToClipboard = (input: string) => {
+	const $el = document.createElement('textarea');
+	$el.value = input;
+
+	// Make sure we hide the element from sight
+	$el.setAttribute('readonly', '');
+	$el.style.position = 'absolute';
+	$el.style.left = '-9999px';
+
+	document.body.appendChild($el);
+
+	// Select the input, this is the same as dragging your cursor over it.
+	$el.select();
+	// Copy the current selection to the clipboard
+	document.execCommand('copy');
+
+	// Finally, clean up after ourselves
+	document.body.removeChild($el);
+};
+```
+
+## Context
+
+Surprisingly, copying arbitrary input to the system clipboard (`CMD + C` / `CTRL + C`) isn't provided by default in the DOM.
+
+As a result we need to create our own function to create those `Copy to clipboard` buttons you see all over the place.
+
+This is the exact same version of the `copyToClipboard` function that's used on this website for the code snippets.
+
+## How it works
+
+Under the hood, `copyToClipboard` creates an invisible `textarea` and inserts it into the DOM. We can then use _this element_ to execute the DOM commands to select the text and copy to clipboard.
+
+One consideration is that selecting the text of a hidden `textarea` might focus the document, which could potentially be problematic for screen reader users.
+
+## Usage
+
+```ts
+// This could be anything—an API token, code sample, etc.
+const inputContents = '1234-5678-91011';
+
+// Then you just pass your input into the function! You can attach it to
+// a click event like you normally would in raw JS / your framework of choice.
+copyToClipboard(inputContents);
+```
+
+## Tests
+
+This function's actually a little nasty to test in `jest` since JSDOM doesn't support `document.execCommand`. So you can test that the clipboard command was executed, but you can't _actually_ access clipboard contents in JSOM.
+
+```ts
+import { copyToClipboard } from '../copyToClipboard';
+
+const originalExecCommand = document.execCommand;
+
+beforeEach(() => {
+	document.execCommand = jest.fn();
+});
+
+afterEach(() => {
+	document.execCommand = originalExecCommand;
+});
+
+test("should copy the input to the user's clipboard", () => {
+	copyToClipboard('test clipboard');
+	// We can't test the actual clipboard contents, but we can test that
+	// the `execCommand` function was properly fired.
+	expect(document.execCommand).toHaveBeenCalledTimes(1);
+	expect(document.execCommand).toHaveBeenCalledWith('copy');
+});
+```

--- a/apps/website-sv/src/content/writing/cra-to-nextjs.md
+++ b/apps/website-sv/src/content/writing/cra-to-nextjs.md
@@ -1,0 +1,80 @@
+---
+title: Lessons from our ~7 month migration to Next.js
+date: 2024-04-27
+tags:
+  - nextjs
+---
+
+In October 2023 I completed a migration from Create-React-App (CRA) to Next.js at [work](https://sublime.security/).
+
+Before I get too far into what I _learned_ from this migration, a quick word — this post isn't about why you should migrate to Next.js. It's also not a tutorial.
+
+However, answering "why?" and "how?" is essential for any successful migration, so I'll offer a quick summary.
+
+## why?
+
+This [Github comment](https://github.com/facebook/create-react-app/issues/11180#issuecomment-874748552) summarizes the reasons we got off of CRA. In short, it wasn't ever intended for production-grade software applications, and our app was suffering from a good deal of [accidental complexity](https://worrydream.com/refs/Brooks_1986_-_No_Silver_Bullet.pdf) as a result of being on top of CRA and React Router.
+
+We picked Next.js because we could incrementally migrate without immediate changes to the architecture (keep the same bundler, rendering techniques, infrastructure, etc). Secondly, at the time (March 2023) it was more established and stable than the alternatives, and I have a good deal of history with Next.js which de-risked some unknowns.
+
+_Sidenote — I know it's become trendy to hate on Next.js' instability. I've been using it since v3 and have not had difficulty upgrading. But your experience may be different!_
+
+## how?
+
+Our migration followed a fairly standard "[strangler fig](https://martinfowler.com/bliki/StranglerFigApplication.html)" pattern — we wrapped the existing React Router app inside a catch-all route. Then we migrated route-by-route until there were none left.
+
+On the infrastructure front, we kept the existing Docker image (nginx) as-is, serving a fully client-rendered application. The initial plan was to migrate all of the routes first, and swap to a Node.js image at the end. However, we ended up swapping the image to Node.js in the 3rd week to solve some product bugs (needed some route rewrites on some third-party APIs, and also needed server rendering for some routes to have better SEO).
+
+In total, the migration ran from March 2023 to October 2023. For the first few months it was just myself, and in the last few months of the migration there was another engineer working on route migration alongside me.
+
+Finally, we only had ~2 weeks where we were working on the migration full-time — for the bulk of it we were migrating 1-2 routes when we had spare chunks of time. The rest of our time was spent on regular feature development.
+
+## lessons learned
+
+Overall, I'm proud of the migration and consider it a success — we're a small team, and we were able to ship a major architectural improvement without (too many) hiccups. We also did not pause on shipping customer-facing features over the course of the migration.
+
+I didn't expect it to take me ~6 months to sit down and write about the migration. However, one benefit is that I've had a good amount of time to reflect on what I'd like to highlight about it.
+
+### plan in shippable chunks
+
+Don't plan to ship your migration in one go. Instead, plan the migration so that you can ship pieces incrementally.
+
+This vastly decreases the level of risk you take on. You may hit the exact same bugs, but you've smeared them over weeks / months instead of a single release. You'll probably notice them (and fix them) long before your users do.
+
+You can also hit "pause" on the migration at any point. This allows you to respond to real business needs. You can ship new features, fix bugs, go on-call, etc — all while making sure that the migration progresses forward, step by step.
+
+Incremental, pausable chunks is the only way to safely finish the migration without losing your sanity. You may never need to hit pause, but more often than not you'll need that option to be available.
+
+### provide actual business value
+
+If you want your migration to be considered a success it needs to provide some actual value to the business.
+
+Granted, business value™ has a lot of flavors. Sometimes it's a direct line between the code and the money it brought in. Other times it's fuzzier things like "dev productivity".
+
+In our case, Next.js opened a few doors early-on. More specifically, it afforded us an easy way to proxy some third-party dependencies, and it allowed us to build a couple features (dynamic og images) that would have been tricky without it.
+
+We've also gotten some of the fuzzier business value as well — we removed a bunch of outdated dependencies, our dev server starts faster, and our codebase has a bit more structure.
+
+### limit concurrent migrations
+
+One danger with incremental migrations is never finishing them. Every time you hit pause, you risk never hitting play again. Then your codebase gets permanently stuck in limbo.
+
+However, you can intentionally limit how many migrations you take on. Deliberately holding off on starting that next migration until you've finished the one on your plate. We had a few migrations (forms, data tables, some UI elements) that we intentionally delayed until we finished Next.js.
+
+Make sure not to stretch yourself too thin — we're only human after all.
+
+### keep the handoffs simple
+
+One initial mistake that I made was adding a fancy handoff between the React Router and Next portions of the app. I made a special `MigrationLink` component that knew which router it was jumping into based on the link. The goal was to allow seamless client-side routing, even when crossing across the router boundary.
+
+That turned out to be a huge, buggy mess.
+
+Eventually we stopped using `MigrationLink` in favor of just rendering a raw `a` tag every time we crossed the router boundary. This ended up being much simpler and less buggy, at the cost of a full-page refresh.
+
+By simplifying the boundary between the two systems we made the migration much more stable and created less mess for ourselves to clean up later. And our customers didn't mind!
+
+## final thoughts
+
+This post is long overdue — while completing the migration was one thing, collecting my thoughts and sitting down to write an article took just as long as the migration! 😅
+
+I'm very proud of the work that we did — I've seen a lot of "big bang" migrations over my career, but not as many incremental, pausable migrations. Since joining Sublime Security I've done a handful of these incremental migrations and I'm firmly becoming convinced that it's _the best way_ to ship large architectural changes.

--- a/apps/website-sv/src/content/writing/dev-only-routes-in-nextjs.md
+++ b/apps/website-sv/src/content/writing/dev-only-routes-in-nextjs.md
@@ -1,0 +1,96 @@
+---
+title: Dev-only routes in NextJS
+date: 2020-09-05
+tags:
+  - nextjs
+  - front-end
+---
+
+I've found myself often wishing that NextJS had a way to optionally hide **entire pages** from the production builds.
+
+For example, on this website I have a small design system—it helps me keeps things like colors, spacing, and border-radii consistent. I also have a single page containing all my components so that I can easily workshop and test them. However, that's a page that I don't see too much value in sharing with the entire world (yet)—it's just a dev tool for myself.
+
+For a big-scale design system (like what you'd build at a company), you'd likely have a separate repository with something like [Storybook](https://storybook.js.org/), [Playroom](https://github.com/seek-oss/playroom), or [StyleGuidist](https://react-styleguidist.js.org/) set up. However, that can be a large amount of overhead to maintain—especially if you're a small team (or a single dev). Sometimes the size of the project doesn't justify having a separate repo of components.
+
+NextJS doesn't have anything built-in that lets us optionally hide a page (to my knowledge), but we can use a couple of its page-creation APIs to achieve the exact same experience.
+
+---
+
+## tl;dr
+
+We can leverage NextJS' [dynamic routes](https://nextjs.org/docs/routing/dynamic-routes) and [`getStaticPaths`](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation) to optionally render routes based on environment variables. This is useful for things like website documentation and partially finished work.
+
+---
+
+## What are the "specs"? 📝
+
+Before we dive into the code, let's define exactly what we want to achieve. For me, it's a couple things:
+
+- Whether we enable the page should be adjustable with an _environment variable_. This fits in nicely with [12-factor app](https://12factor.net/config) philosophy.
+- If the page is not enabled, _its route should return a 404 response_, as if the page never existed.
+- If the page is enabled, _it should display the content_ normally.
+
+## Show me the code! 🙃
+
+To leverage this approach, we'd need to place the following page code in a file within the `pages` directory. To properly leverage dynamic routing, we also need the filename to be encased in square brackets. For example, `pages/docs/[component].jsx`.
+
+```jsx
+// pages/docs/[component].jsx
+
+const DevOnlyPage = () => {
+	return <div>test!</div>;
+};
+
+// Even though there isn't any "dynamic" data flowing into our page component
+// we can leverage `getStaticPaths` to dynamically determine _which_ pages should
+// be built.
+export const getStaticPaths = () => {
+	const paths = [];
+
+	// If the environment variable is available, push some pages. This gives you
+	// fine-grained control over whether or not pages are added.
+	if (process.env.BUILD_DOCS === 'true') {
+		// `component` lines up to the page name of [component].jsx
+		paths.push({ params: { component: 'design-system' } });
+	}
+
+	// If `paths` is empty, all paths at this route will return 404 responses, same
+	// as if we never had the page at all.
+	return {
+		paths,
+		// This is important, using `fallback: false` means that all routes not
+		// returned from this function return 404 responses.
+		fallback: false
+	};
+};
+
+// Even though we're not dynamically getting any props, `getStaticPaths` doesn't
+// work without `getStaticProps`.
+export const getStaticProps = () => {
+	return {
+		props: {}
+	};
+};
+
+export default DevOnlyPage;
+```
+
+## Trade-offs
+
+One of the big tradeoffs of this approach is that you _have_ to use NextJS' dynamic routes and `getStaticPaths`. This potentially breaks away from NextJS' opinionated "every route is a page component" philosophy if you have multiple pages under a single route (i.e. `/docs/design` and `docs/architecture`).
+
+If you have multiple dev-only pages on a parent route, you might need some lightweight conditional logic in your page component. You can return the page name from `getStaticProps` and use that to conditionally render each dev-only component.
+
+One potential workaround (I haven't tried it yet) is using an [_optional catch-all route_](https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes) to do the dynamic routing. This might make multiple dev-only routes a little simpler.
+
+## Some potential use cases 🤔
+
+Here's a couple cases where I think an approach like this could be useful:
+
+- Previewing your design system. This was the original use case that made me investigate this approach.
+- Partially finished work. For example, if you're building a new page that's gonna take a multiple PRs but you don't want to expose it. You can use this approach as a simple method of feature-flagging routes to keep them out of production.
+- This approach could be a nice way to host dev-only documentation (for example, [ADRs](https://github.blog/2020-08-13-why-write-adrs/)) without exposing it in your production environments.
+
+---
+
+Thanks for reading! As always, feel free to [let me know on Twitter](https://twitter.com/benjamminj) if you enjoyed the article or [submit a PR](https://github.com/benjamminj/portfolio) if you found a typo!

--- a/apps/website-sv/src/content/writing/empathetic-code.md
+++ b/apps/website-sv/src/content/writing/empathetic-code.md
@@ -1,0 +1,77 @@
+---
+title: Coding with empathy
+description: It's important to write code with emotional awareness. When we forget that code is also for humans to read, we end up with scary codebases that make the future maintainers of our code sad.
+date: 2019-02-07
+image:
+  url: 'battle-board-game-pieces.jpg'
+  alt: A team of four game pieces stand in a row
+tags:
+  - teamwork
+  - software-engineering
+---
+
+I'm a big fan of [April Wensel](https://compassionatecoding.com/) and her talks on "compassionate code". I love how she drives home the point that software engineering is fundamentally about working with other humans. Yes, it is incredibly important that we have technical expertise, but we also need to be experts in collaboration.
+
+In order to collaborate effectively we need to be engineers that have a high degree of _emotional intelligence_. And while this certainly means decreasing workplace toxicity, emotional intelligence also extends to the code we write. That's what we'll be exploring in this post—writing code with empathy in mind.
+
+## But how can code be empathetic?
+
+It's a good question to ask. After all, we often think of empathy as something connected to our interactions with other people, and we think of code as the time when we get to be "purely technical".
+
+However, as authors of the code we write, we have an opportunity to practice empathy for our code's future maintainers. When we write code that takes into account how future maintainers will feel reading it, we approach our job differently. All of a sudden it become less about just getting things to work or pushing out feature after feature. Instead we start to care about maintainability, readability, and simplicity.
+
+There's a familiar programming quote from [Code For The Maintainer](http://wiki.c2.com/?CodeForTheMaintainer) that emphasizes this aspect of empathy (along with a little melodrama).
+
+> “Always code as if the person who ends up maintaining your code is a violent psychopath who knows where you live.”
+
+What I love about this quote is that it taps into our survival instinct to remind us that it's important to think of the future people that will maintain the code we write today. Sometimes that future maintainer is yourself, sometimes it's someone you've never met. And while it's rare that the future maintainer is gonna come stalking you with murderous intent, they are still human. It's vital that we write code that makes their job a joy—not a living hell.
+
+## So how do we write empathetic code?
+
+A lot of the software industry loves this idea of code being "clean", first introduced by Robert Martin in his book "[Clean Code](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882)". And while I like a ton of these clean coding principles, I think we miss a lot if we only focus on "best practices" or a list rules to make our code "clean" or "unclean".
+
+Instead, I think it's important for us to frame these software "best practices" through the lens of empathy and how they affect the people that consume our code (perhaps other developers using an internal module's API) or make updates to our code. That way it becomes less of a checklist of things that we "have to do" and more established into the _way that we do things_.
+
+Let's take a quick look at some of these software practices, framed through the lens of empathy:
+
+### Automated Tests
+
+Tests are a great way to provide long-term safety to a module of code. By automatically verifying that the code works, they serve as one of the first line of defense against costly bugs and regressions. When I open up a file for the first time and see that it has some comprehensive test coverage, I feel complete freedom to make whatever changes I need to—without the fear of breaking things! By contrast, opening a file without any tests can be downright terrifying. When we write tests we're not only saving our business [time and money](https://medium.com/javascript-scene/the-outrageous-cost-of-skipping-tdd-code-reviews-57887064c412), we're making sure that the future maintainer of our code can feel safe about modifying it.
+
+### Consistent styling
+
+Having a consistent code style goes a long way towards making life easier for future maintainers. Syntax and formatting issues tend to be low-hanging fruit that can usually be automated with tools like [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/) (if you're writing JavaScript, for other languages you might need different tools).
+
+Having a consistent code style is empathetic because it allows your teammates to understand the code faster. Not forcing them to spend extra brain cycles reading through inconsistently formatted code allows them to focus on what actually matters: the problem they are trying to solve.
+
+### Choosing good variable names
+
+There's another quote from "Clean Code" that goes along the lines of "you should name every variable with the same care that you would give to naming your firstborn child".
+
+While the metaphor may be a bit hyperbolic, the point still stands: how you name things matters. By spending that extra (often small) effort up-front to choose a descriptive name, you help your team (and your future self) gain context about the code. In the moment we know extra context about _why_ our code is the way it is, so that's the best time to choose a descriptive variable name to remind future maintainers of that context.
+
+### Adding comments
+
+If you can't fit all of the context inside a variable name, leave a helpful comment along with whatever name you chose!
+
+You might have heard some people say that "code should be self-documenting so comments are unnecessary". While it is true that we should strive to make our _code_ as clear as possible, a well-placed comment can pack a ton of extra context that you wouldn't really be able to fit inside a variable.
+
+I'm a big fan of using comments to explain the _why_ behind the code. We don't really need to comment that a `for` loop iterates through the list, but if it's there to solve a specific edge case it's helpful to know what that edge case is. Adding a comment can be super valuable when some future developer stumbles across that code and is trying to figure out exactly why it's in the codebase. That way they know whether it's safe to delete that code or not.
+
+### Documentation
+
+A great way to measure the empathy of your codebase is to watch what happens when a new team member comes on board. How long does it take for them to get the app running locally? What types of questions are they asking? What types of things are they "doing wrong" in their first few PRs?
+
+If you don't have any new team members coming onboard for a while, put yourself in the shoes of a junior developer starting their first day at your company. What types of things about your codebase would be confusing or unclear?
+
+One of the best ways to fight unclarity is through a good set of documentation. Having clear, well-written docs about getting the app running or performing certain tasks can go a long way towards making a codebase friendly and inviting instead of unclear and daunting.
+
+However, docs also have to be written with empathy in mind! Making sure that documentation is extensive enough to provide clarity while not coming across as belittling is a fine balance. One way that I try to assess the clarity of my docs is to "optimize for copy-paste". Assume that the person reading your documentation is going to copy-paste your examples into their code because they're trying to solve a complicated problem on a time crunch. Thinking about docs in this way forces you to write examples that are fully fleshed out.
+
+### And many more!
+
+This is definitely not an exhaustive list of the ways to make our code empathetic. In fact, any of the "best practices" out there could be looked at through the lens of empathy. Take a couple of the best practices that you're passionate about and think about how they positively impact future maintainers and you'll see what I'm talking about!
+
+## Conclusion
+
+At the end of the day, engineering is about communication—we tell the computer what operations to execute, and we tell our teammates what the code is supposed to do. And while the computer doesn't care about how empathetic our code is, our teammates and future maintainers do. By focusing on empathy in the code we write, we will produce higher quality software as a byproduct.

--- a/apps/website-sv/src/content/writing/encapsulation-better-than-reuse.md
+++ b/apps/website-sv/src/content/writing/encapsulation-better-than-reuse.md
@@ -1,0 +1,17 @@
+---
+title: Encapsulation > reusability
+description: Focus on encapsulation, and you'll get reusability as a byproduct.
+date: 2022-01-01
+tags:
+  - software-engineering
+---
+
+Encapsulate well and you'll get reusability for free. But it doesn't go two ways: a highly reusable module isn't necessarily well encapsulated.
+
+One reason encapsulation breeds reuse is due to the nature of _hiding information_. Encapsulation allows us to take complex information and stuff it in the closet. Instead of seeing all the complex mess, we've hidden it behind a simpler interface.
+
+In contrast, a module can remain highly reusable while exposing all its complexity. A [leaky abstraction](https://en.wikipedia.org/wiki/Leaky_abstraction) can be still be widely used. But there's a catch: to use it effectively you need to know how it works internally.
+
+If you want to get more reusable code, focus first on abstraction. Ask yourself, "what complexity does this module hide?" If the answer is "none", get rid of the module entirely. [Code that looks the similar isn't always the same.](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction)
+
+Reuse isn't the goal, it's the byproduct.

--- a/apps/website-sv/src/content/writing/encapsulation.md
+++ b/apps/website-sv/src/content/writing/encapsulation.md
@@ -1,0 +1,33 @@
+---
+title: Encapsulation
+date: 2022-01-01
+tags:
+  - software-engineering
+  - definitions
+---
+
+## tl;dr
+
+> _**Encapsulation:** hiding the specific information about a portion of code._
+
+---
+
+We have tons of examples of encapsulation outside the software world.
+
+When you drive a car, you don't need to know about everything happening inside the engine, you use the steering wheel & 2-3 pedals to control the whole thing.
+
+When you unlock a door, you're using a simpler interface for a [complex locking machanism](https://en.wikipedia.org/wiki/Lock_and_key). But all you do is insert the key, turn, and push.
+
+The same ideas apply to writing software, we use encapsulation all the time without thinking twice. Consider this sample JavaScript.
+
+```js
+JSON.parse(someJSONValue);
+```
+
+When you call `JSON.parse`, you don't need to know everything about _how_ the JSON gets parsed, you only need to know a few things: the JSON you want to parse, and that you get back a parsed JS object (or array).
+
+_(Yes, I know `JSON.parse` takes a couple arguments, but these are optional)._
+
+Encapsulation is fundamental for building large software systems. Hiding complex information about a module allows others to use that module to build bigger things. We allow the people to _focus_ on a single piece of an application without holding everything in their head at once.
+
+In short, encapsulation is the name of the game when it comes to software. we'd all do well to spend lots of brain cycles on encapsulating well.

--- a/apps/website-sv/src/content/writing/engineering-values.md
+++ b/apps/website-sv/src/content/writing/engineering-values.md
@@ -1,0 +1,127 @@
+---
+title: Engineering values
+date: 2020-10-30T22:21:15.099Z
+tags:
+  - software-engineering
+  - philosophy
+---
+
+Recently I've been thinking about high-level values as they pertain to software engineering.
+
+You can tell a lot about an engineering team by their **practices**, but that won't tell you the **values** driving those practices. Engineering values serve as a guiding light driving engineering practices. Rather than a list of rules to follow, values give us the "why" behind the things we do.
+
+## A couple caveats
+
+First, this list isn't exhaustive. There's probably things that I forgot. There's probably things that I'll add as time goes on.
+
+Second, this is a living document. I plan on coming back to this periodically as my views and engineering values evolve.
+
+Finally, if you don't do everything here, that doesn't instantly make you a "bad" engineer. Some of these practices are things I'm currently learning and haven't had extensive experience in.
+
+---
+
+## People first
+
+> _Software development is about real people. Code has two primary audiences—the developers coding on top of it (internal) and people using it (external)._
+
+While programming can be artistic and code can be elegant—elegant code is not the end in and of itself. Rather, it's a path to the goal of serving these two audiences.
+
+You serve the internal audience (often future you!) when your code is easy to work with. You serve the external audience when they actually use the things that you create!
+
+### Supported engineering practices
+
+- Documentation
+- Code comments (commenting the "why")
+- Automatic formatters and linters
+- Intuitive APIs (well-thought-out, ergonomic, understandable interfaces)
+- Accessibility
+- ADRs
+- Good variable names
+- Developer experience (DX)
+- Automation (automate as much as is reasonably possible)
+- Simple code over clever code (however, "simple" is often up to interpretation)
+- Static type systems (TypeScript, Flow, ReasonML)
+- User testing & research
+- A/B testing
+- Timely refactoring (don't abstract too early)
+- Reasonable work hours (no death marches)
+
+## Duplication is better than bad abstractions
+
+> _Undoing a bad abstraction is more difficult than creating an abstraction for some duplication. Wait to write abstract "DRY" code until you know enough about what you need to create a good interface._
+
+This principle is heavily influenced by Sandi Metz's [The Wrong Abstraction](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction).
+
+### Supported engineering practices
+
+- Regular refactoring (both at dedicated times and as-you-go)
+- Automated tests (especially integration and end-to-end tests)
+- Static type systems
+- Code comments (commenting the "why")
+- "Hot garbage architecture"
+- Timely refactoring
+
+## Optimize for flexibility
+
+> _Changing requirements are to be expected, perhaps even the norm. Optimize code to be flexible and pliable so you can iterate on and polish it over time._
+
+### Supported engineering practices
+
+- Composition
+- Automated tests
+- Static type systems
+- Regular refactoring
+- Documentation
+- Code comments
+- ADRs
+- Timely refactoring
+- Continuous deployment
+- Continuous integration
+- Feature flags
+- Colocation of files (optimizing to delete code)
+- "Hot garbage architecture"
+- Pragmatic guidelines over dogmatic laws
+
+## Backwards compatability
+
+> _Don't break things. Have confidence that your new code doesn't break your old code._
+
+### Supported engineering practices
+
+- Semantic versioning
+- Automated tests
+- Feature flags
+- Continuous integration
+- Code reviews / pull requests
+- Preview apps
+- Static type systems
+- Observability
+
+## Ship early and often
+
+> _Ship to production as quickly as you possibly can without breaking things. Code in production is money code, and that's the code you're motivated to keep healthy._
+
+### Supported engineering practices
+
+- Feature flags
+- Trunk-based development
+- Automated tests
+- Continuous deployment
+- Timely performance optimization (measure before you optimize)
+- Observability
+
+---
+
+## Additional Resources
+
+No one comes up with engineering values in a vacuum. Over time we pick up ideas from conference talks, blog articles, and coworkers. We try things out and watch them succeed or fail.
+
+In short—we learn.
+
+Here's some conference talks and articles that have been a huge influence on these engineering principles:
+
+- [The Wrong Abstraction](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction) by Sandi Metz
+- [Hot Garbage: Clean Code is Dead](https://www.youtube.com/watch?reload=9&v=-NP_upexPFg) by Michael Chan
+- [A Codebase is an Organism](https://meltingasphalt.com/a-codebase-is-an-organism/) by Kevin Simler
+- [On the Spectrum of Abstraction](https://www.youtube.com/watch?v=mVVNJKv9esE) by Cheng Lou
+- [Figma's Engineering Values](https://www.figma.com/blog/figmas-engineering-values/) by Thomas Wright

--- a/apps/website-sv/src/content/writing/friends-dont-let-friends-write-react-boilerplate.md
+++ b/apps/website-sv/src/content/writing/friends-dont-let-friends-write-react-boilerplate.md
@@ -1,0 +1,55 @@
+---
+title: Friends Don't Let Friends Write React Boilerplate
+description: If the core of your app could be done on top of a "boilerplate framework", save yourself some time & effort—focus on delivering an awesome user experience.
+date: 2018-02-13
+image:
+  url: 'pies.jpg'
+  alt: Three pies on a table
+---
+
+Have you ever made a pie? If you have, I'm sure you know the amount of detail & precision that goes into that perfect "from-scratch" recipe. Wait a couple minutes too long, and the crust burns. Use too much butter and your pie doesn't have the right texture. Making a creme pie? If you get the measurements wrong your pie could end up as soup (been there, done that. At least it was a tasty mistake).
+
+Makes you wonder why we say "easy as pie", right?
+
+One of the biggest complaints from people about the current JavaScript ecosystem is the state of the tooling. Starting a React project could require 1-3 **days** of setup to get everything working correctly. You've got transpilers, module bundlers, linters, formatters, test runners, etc. Juggling all of these can feel very much like baking a pie &mdash; make one mistake, and you're knee-deep in webpack internals trying to figure out why you can't even get "Hello World" to show up. In many ways it can feel just like baking a pie.
+
+Most of the front-end frameworks have CLIs or boilerplates to alleviate this pain, but conventional wisdom would have you think that writing your own webpack config will result in higher productivity down the road (because after all, you know how it works so you can customize as much as you want). I still see people posting/talking about how good it is to create your own boilerplate.
+
+Most of the time, you don't need a custom boilerplate. Here's why.
+
+## A Couple Disclaimers 🙃
+
+Software engineering is _filled_ with tradeoffs, and the time spent working on tooling is no exception. There may be some cases where spending a bunch of time setting up your project actually does help in the long term. Before we get into details, I wanted to make these two disclaimers, lest anyone draw the wrong conclusions.
+
+- **Learning tooling isn't a waste of time.** But it can be a large barrier to learning something new / delivering faster. There's a lot of tiny choices that you will spend energy on if you spend a lot of time configuring your build chain, and each one of those choices wear you down a little. The good news is that webpack & the other build tools have _amazing docs_ (for the most part), so when you do need to update something, you can usually figure it out on a case-by-case basis.
+- **You might need custom functionality, and that's ok.** I understand that some use cases merit a custom configuration built-from-scratch. But I would also argue that in many cases (especially side projects) these are the exception and not the rule. In addition, you can often build your custom functionality on top of an off-the-shelf solution.
+
+Ok. Now that we've got that out of the way, let's get into the why.
+
+## There's a Lot of Good "Boilerplate Frameworks" Out There
+
+For lots of apps, you can piggy-back off of the myriad of boilerplate & bootstrapping frameworks out there. In the React ecosystem, here's 3 of the most popular.
+
+1. [Create-React-App](https://github.com/facebook/create-react-app) (great for smaller projects & learning React! Also lets you "eject" & customize however you want)
+2. [NextJS](https://github.com/zeit/next.js/) (server-rendering framework with a rich plugin ecosystem)
+3. [Gatsby](https://www.gatsbyjs.org/docs/) (static site generator built on React & GraphQL. Also has a lovely plugin ecosystem).
+
+I use the term "boilerplate frameworks" to describe these type of frameworks/bootstrapping packages since they're not _boilerplates_ in the strictest since of the term. In a boilerplate, you'd typically have access to all of the generated/prepopulated code. However, they allow you to quickly bootstrap an app, fulfilling the initial purpose a boilerplate is meant to serve.
+
+All three of these "boilerplate frameworks" provide opinionated defaults while allowing options for developers to extend functionality. Before you go and spend a bunch of time writing your own config, see if one of these fits what you're looking for (many times it will!). And if you need something one of these doesn't provide, see if there's a plugin (in the case of Gatsby / NextJS, Create-React-App doesn't have plugin functionality). Building on top of one of these solutions or using a plugin with save you **hours** of setup time, meaning you can get your code out to users faster.
+
+## Remember That If You Write Your Own Config, You Will Have to Maintain It.
+
+A lot of these boilerplate frameworks will regularly release updates with security & dependency updates. If your app is built on top of it, you'll get these for free (and fairly painlessly).
+
+Writing your own configuration is a two-edged sword &mdash; you get to update it _any time you want_. You don't have to wait on open source contributions or for the next release. You can change things _today_.
+
+However, when your build pipeline is breaking, you alone have to fix it. When one of your dependencies needs to be updated & that update breaks your build system, you have to dig into the config & _debug your tools_.
+
+Just remember that any time spent debugging your tools is time that you could have spent writing the code that makes your application unique.
+
+## Last Thoughts
+
+A big thanks to [Kyle Holmberg](https://medium.com/@kylemh) for the phrase "Friends Don't Let Friends Write React Boilerplate". He's a super cool developer, also doing frontend web engineering at [AutoGravity](https://www.autogravity.com). Check out his articles, they're super great. 👌🏻
+
+At the end of the day, writing software should be focused on the end users. If that extra time spent on your own config allows you to make things that benefit them, go for it. But if the core of your app could be done on top of a "boilerplate framework", save yourself some time & effort &mdash; focus on delivering an awesome user experience.

--- a/apps/website-sv/src/content/writing/function-vs-arrow.md
+++ b/apps/website-sv/src/content/writing/function-vs-arrow.md
@@ -1,0 +1,92 @@
+---
+title: '(Personal) code preferences: arrow functions'
+date: 2020-08-20
+tags:
+  - javascript
+  - formatting
+---
+
+> [!WARNING]
+>
+> These represent my opinions at the time of writing. As of right now (June 2024) they're not
+> my current preferences: I'm team `function` keyword because Reasons™.
+>
+> Truly a testament to formatting be aesthetic taste — sometimes tastes change!
+
+Most opinions about code formatting boil down to personal preference.
+
+They're like [Oxford commas](https://www.grammarly.com/blog/what-is-the-oxford-comma-and-why-do-people-care-so-much-about-it/) or essay citations—whether it's "right" or "wrong" depends on the judgment of the style guide you're using.
+
+Styling code consistently is still important. Notably, [it makes scanning and reading code easier](https://benjaminjohnson.me/blog/empathetic-code), especially if that code was written by multiple authors.
+
+But most formatting decisions _are_ based on preference. There isn't an objectively better choice.
+
+As you write code, you'll develop your own preferences about how things should be formatted. And those styling decisions should have _real, valid reasons_ backing them.
+
+Sometimes that reason is "I like the way it looks better", and that's ok.
+
+Sometimes that reason is due to language nuances or edge cases, and that's ok.
+
+But when you work on a team it's important to divide the important formatting decisions from the ones that are purely personal preference. Spending valuable time arguing with your team over small formatting choices is a prime example of ["bikeshedding"](https://en.wiktionary.org/wiki/bikeshedding).
+
+This article is the first in a series that I have lined up in which I'm writing about _my personal preferences_ and the reasoning behind them.
+
+I fully recognize that my way isn't the only valid way. But it's still valuable to capture **_my_** preference and the reasoning behind it.
+
+I'm perfectly fine laying these preferences aside when working within a team. I often have—I'm a firm believer that preferences like this should be delegated to [formatter and linters](https://benjaminjohnson.me/blog/giving-up-control-to-your-tools) instead of taking up human effort.
+
+In this article I'll be sharing my preferences on **_arrow functions and the `function` keyword_**.
+
+---
+
+## Prefer arrow functions to `function`
+
+Instead of writing JavaScript functions using the `function` keyword, just declare them as an arrow function and attach it to a variable.
+
+```js
+// Using `function`
+function add(a, b) {
+	return a + b;
+}
+
+// Using an arrow function
+const add = (a, b) => a + b;
+```
+
+## Why?
+
+I prefer using this syntax because it results in a consistent way to declare functions in a codebase.
+
+Even if you use `function` at the top level, chances are you'll have a number of arrow functions littered around your codebase. For example, inside of `Array.map`, callbacks, and React components' props.
+
+I found that when I used a mix of `function` and arrow functions I had to _decide_ when to use each. Do you do `function` at the top level, arrows everywhere else? `function` when it needs a name, arrow when it's anonymous?
+
+If you're not using `this` they'll mostly likely be equivalent, so it's a purely stylistic decision. There's a few nuances, hold tight for the "Disclaimers" section and we'll get to those.
+
+Defaulting to arrow functions means there's one less decision that I have to make when writing functions.
+
+Having a consistent style for functions also makes refactoring a bit easier. I'm able to pull existing arrow functions into separate files or up to the top level without having to convert them to `function` syntax.
+
+Finally, I like the syntax of the arrow functions a little better. This is purely stylistic—I think the syntax feels a little lighter and draws focus to the functions' input and output.
+
+## Disclaimers
+
+You can't just replace every `function` with an arrow haphazardly. There's a few cases where using an arrow function instead of `function` is required, and vice versa.
+
+If you're using `this`, `arguments`, `super` or `new.target`, it's important which one you use. Arrow functions won't have any of these bound to itself—they'll just look in their surrounding context.
+
+Named arrow functions (`const name = () => {}`) don't [hoist](https://scotch.io/tutorials/understanding-hoisting-in-javascript) to the top of their scope, while `function` does. If you like organizing your code in ["newspaper structure"](https://kentcdodds.com/blog/newspaper-code-structure), then you're much better off using `function`.
+
+Finally, a couple common gripes about arrow functions that I've heard commonly (either in person or on the internet).
+
+- A common argument against arrow functions that they're not actually shorter than using `function`. _Technically_, arrow functions are a few more characters (if you're not using the [implicit return](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)). I still think the syntax is more compact—it neatly fits on a single line in a way that's easy to scan the inputs and outputs.
+
+- Some complain that arrow functions have too many syntax variations. This is a valid complaint—there's a lot of different ways to write arrow functions. But I haven't seen many engineers get tripped up by them. If you're using a tool like Prettier you can just [let it deal with formatting your arrow functions consistently](https://benjaminjohnson.me/blog/giving-up-control-to-your-tools).
+
+- One of the common complaints about arrow functions is that they show up as "Anonymous function" in a stack trace. This is mostly FUD (fear, uncertainty, and doubt). If you use `function` without a name it'll also appear as "Anonymous" as well. If you assign the arrow function to a variable the name shows up just fine.
+
+---
+
+## tl;dr
+
+I prefer using arrow functions over the `function` keyword. Reasoning behind this preference includes: consistent function syntax, ease of refactoring, and compactness.

--- a/apps/website-sv/src/content/writing/getting-your-first-software-engineering-job.md
+++ b/apps/website-sv/src/content/writing/getting-your-first-software-engineering-job.md
@@ -1,0 +1,65 @@
+---
+title: Getting your first software engineering job
+subtitle:
+date: 2021-09-23
+tags:
+  - career
+  - job-searching
+---
+
+As a musician turned bootcamp-grad turned software engineer, I get asked frequently about my thoughts about breaking into the industry. "What do I need to do to get that ever-elusive first software engineering job?"
+
+To be honest, it's hard to answer. I wish I could say "follow these 4 easy steps and you'll have a job in 4 months", but job searching isn't formulaic. It varies from person to person.
+
+## First, a word of caution about job searching advice
+
+Take other people's tips with a grain of salt — mine included. These are things that worked for **me**, but they may not apply 100% to your situation.
+
+Here's a few aspects to note about my job-search in 2017 that might differ from your experience:
+
+- **The entry-level market has shifted.** Companies expect junior engineers to know a lot more today than I did as a junior engineer. COVID-19 opened up many remote opportunities but it also means global competition for roles.
+- **Demographics and unconscious bias.** I'm a white man, and I entered tech in my mid 20s. Depending on your demographic, my experience may differ from yours. Lots has been said about how we can decrease bias in hiring; that's another article entirely.
+- **Personality.** I'm outgoing and personable. I'm ADHD. These tips worked for me based on my personality. YMMV.
+
+## Stand out from the crowd
+
+Entry-level jobs are scarce, so competition is fierce. If you want to get an interview you need to stand out from the rest.
+
+- **Build real projects.** Your bootcamp portfolio projects probably look identical to other candidates'. Don't put another todo app, timer, or quiz in your portfolio — build something that's uniquely **you**.
+- **Prefer depth over breadth.** Companies expect when they hire entry-level roles that candidates won't know all the technologies in the job description. They're looking for learning trajectory, and you can showcase this much better by knowing one "main thing" inside-out.
+- **Go beyond what your bootcamp taught you.** Did your bootcamp teach unit testing? CI / CD? TypeScript? If you have the time, learning practices adjacent to your "main thing" can help you stand out from the crowd.
+- **Have a good resume and portfolio.** Compare your resume and portfolio to other entry-level candidates. Does yours looks identical? Your portfolio especially, that's your corner of the internet so put your stamp on it.
+- **Learn to write.** Post on LinkedIn and Twitter. Start a blog (use [dev.to](https://dev.to) to get started quickly). Many won't do this extra work, so if you do it's big points in your favor.
+
+## Network as much as possible
+
+This is how I got my first job. I met a guy at a meetup, he introduced me to someone else, and _that_ person introduced me to the recruiter at my first job.
+
+- **Go to meetups.** Go to as many meetups (remote or in-person) as you can fit in your schedule. Meet new people and get to know them. Someone you meet might just hire you!
+- **Join online communities.** Discord and Slack have lots of developer communities. Some are even geared towards entry-level job-seekers! Twitter and LinkedIn are also great ways to get involved in the online developer community.
+- **Be genuine.** Don't just use people for job leads. Build real connections with the people you meet, it's better in the long run. People can sense when you're inauthentic.
+- **Post on social media.** Get on LinkedIn and Twitter. LinkedIn is where the recruiters are, Twitter is where the dev community (at least for JS) is.
+- **Follow. up.** Don't just meet people and expect them to hand you jobs. Message them and follow up. Ask if they can intro you to people that are hiring. Ask what advice they have for job seekers. Don't meet them once and disappear.
+
+## Think of job-searching as a sales funnel
+
+Job searching is sales. When you accept an offer, you are making a business transaction — you agree to trade your time and skills in return for money and benefits.
+
+View the job search as a sales funnel. You only need to close one sale, but when you think of yourself as "the product" and interviews as "leads" you come across as more confident.
+
+## Iterate and improve.
+
+I often hear about bootcamp grads sending out 500+ job applications or failing 100s of interviews on a single job search. And I often wonder whether they are iterating on their process or not.
+
+Assess **where** your job search funnel is breaking down, and then double down in that area. Are you failing to get past the resume screen? Do you bomb technical interviews?
+
+Don't blindly repeat something that's clearly not working. Either work on improving your performance in that area, or look for a way to "change the rules".
+
+For example, use a network-based approach to skip resume screening entirely. Or don't apply at companies that do algorithm challenges if your computer science skills are weak. Or do interview practice with a friend if you struggle answering questions confidently.
+
+You might have to try a few things before you see improvement. But don't let that deter you from tweaking your job search processes to get the results you want.
+
+## Resources
+
+- [The Standout Developer](https://randallkanna.com/the-standout-developer/) by Randall Kanna. I have not read this myself, but it comes highly recommended by some colleagues. I follow Randall on Twitter and she is full of amazing advice for those entering the software industry.
+- [Taylor Desseyn](https://twitter.com/tdesseyn) on Twitter. Taylor's a recruiter and is also full of job search advice for both senior- and entry-level engineers. I've learned tons about how software recruiting works under the hood from popping into his podcast every once in a while.

--- a/apps/website-sv/src/content/writing/giving-up-control-to-your-tools.md
+++ b/apps/website-sv/src/content/writing/giving-up-control-to-your-tools.md
@@ -1,0 +1,37 @@
+---
+title: Tools like Prettier ask us to give up control
+description: There's nothing wrong about caring about code formatting! Using a formatter requires that we give up fine-grained control and let our tools do the heavy lifting.
+draft: false
+date: 2019-03-01
+image:
+  url: 'plane-controls.jpg'
+  alt: Flight commander tweaks airplane controls
+  by: https://unsplash.com/@byronsterk
+  source: https://unsplash.com
+tags:
+  - formatting
+---
+
+Perhaps you've heard of a tool called [Prettier](https://prettier.io/). If you haven't, Prettier is a code formatter for a variety of languages—JavaScript, TypeScript, CSS, Markdown, GraphQL, and many other languages. It's an amazing tool and I've been a huge fan of having it as a part of my workflow for the past few years.
+
+Working on a project with a formatter installed can be an absolute joy. You simply write code, hit save, and voila! Everything snaps into place and your code is beautifully and consistently formatted across the entire project.
+
+And yet, I've seen a decent amount of pushback when introducing Prettier to a team. I've done this a few times over the past few years, and adoption often been initially met with reluctance. Then, after we start using it Prettier becomes one of the team's favorite tools.
+
+I think one of the main reasons that tools like Prettier receive pushback is simply because it—not developers—formats the code. It remains opinionated by not providing a ton of configuration options. So the code might be formatted in a way that _you_ initially "dislike". Even though the code works 100% the same as it did pre-formatting, it's not the way _you_ "would have formatted it". Perhaps it's the way it breaks lines or handles ternary expressions or you didn't like it adding/removing semicolons.
+
+Prettier doesn't hide the fact that it's opinionated about formatting code. It's chosen description is "An opinionated code formatter". Opinionated tools always comes with an ask. They say, "Leave the formatting to me—don't worry, I've got this."
+
+When we adopt opinionated tools like Prettier we do lose something—fine-grained control over how our code looks. But what we gain in return can make the loss 100% worth it.
+
+When we give control of formatting over to our tools we can eliminate formatting from our mental checklist. I didn't realize how much time and effort I spent deciding whether a function should be broken into a single line vs. multiple lines, trying to hunt down missing semicolons, or other miscellaneous formatting decisions. I sincerely wanted to do the "cleanest" formatting for my code but I'd go back and forth on what formats I liked. Although each of these amount to small decisions, they add up over the course of a day. If we can cut out an entire _category_ of decisions from our workflow, we save more decision-making power for stuff that can't be automated, like variable names, creating good interfaces, and future maintainability.
+
+When we give control of formatting over to our tools we also eliminate an entire class of pull request (PR) comments. Seeing a PR with 50 comments of "semicolon here" or "please break into multiple lines" isn't enjoyable for the reviewer _or_ the author). We can set the PR author up for success if we simply add a formatter to our project workflow—whatever the formatter does is the "right way" for the project. This scopes the conversation about formatting to a single decision—choosing which formatter to add and how to configure it. Instead of spending precious time and energy fighting over style, PR reviewers can focus on the maintainability of the new code and how it fits within the larger ecosystem of the codebase.
+
+When we give control of formatting over to our tools we make our project more welcoming to newcomers. Whether it's someone who's just started learning how to code or a seasoned veteran juggling 3-4 different projects (each with their own formatting requirements), having tools guarantee that every commit and PR is formatted correctly helps these newcomers get up to speed quickly and start contributing value.
+
+---
+
+Tools like Prettier ask us to loosen our grip on code formatting and styling. Many of us are passionate about the code we write—and there's nothing wrong about that! However, this passion often results in us holding on tightly to our idea of what "looks good" or "looks bad". Using a formatter for any team project turns this conversation about style into a one-time decision—which formatter shall you choose, and how shall you configure it.
+
+What about you? Have you encountered pushback when introducing formatters into a codebase? Have you pushed back yourself? I'd love to hear any thoughts you have about what happens when we let our tools take control. If you want you can reach out to me on [Twitter](https://twitter.com/benjamminj) and let me know what you think!

--- a/apps/website-sv/src/content/writing/how-css-works-creating-layers-with-z-index.md
+++ b/apps/website-sv/src/content/writing/how-css-works-creating-layers-with-z-index.md
@@ -1,0 +1,12 @@
+---
+title: 'How CSS works: Creating layers with z-index'
+description: 'This is the final article of my "How CSS Works" series, where I look into one of the most misunderstood parts of CSS: z-index.'
+
+date: 2018-07-02
+publisher: LogRocket
+link: https://blog.logrocket.com/how-css-works-creating-layers-with-z-index-6a20afe1550e/
+tags:
+  - css
+---
+
+This is the final article of my "How CSS Works" series, where I look into one of the most misunderstood parts of CSS—z-index

--- a/apps/website-sv/src/content/writing/how-css-works-parsing-and-painting-in-the-critical-rendering-path.md
+++ b/apps/website-sv/src/content/writing/how-css-works-parsing-and-painting-in-the-critical-rendering-path.md
@@ -1,0 +1,12 @@
+---
+title: 'How CSS works: Parsing & painting CSS in the critical rendering path'
+description: Dive into the critical rendering path and see what happens to the CSS that we write.
+
+date: 2018-04-10
+publisher: LogRocket
+link: https://blog.logrocket.com/how-css-works-parsing-painting-css-in-the-critical-rendering-path-b3ee290762d3/
+tags:
+  - css
+---
+
+This is the first article of my "How CSS works" series, in which I explore CSS fundamentals. In this article I dive into the "critical rendering path" and how the CSS that we write gets turned from code into pixels on the screen.

--- a/apps/website-sv/src/content/writing/how-css-works-understanding-the-cascade.md
+++ b/apps/website-sv/src/content/writing/how-css-works-understanding-the-cascade.md
@@ -1,0 +1,12 @@
+---
+title: 'How CSS works: Understanding the cascade'
+description: When we peel back the layers we see that the cascade isn't as confusing as it seems
+
+publisher: LogRocket
+date: 2018-05-29
+link: https://blog.logrocket.com/how-css-works-understanding-the-cascade-d181cd89a4d8/
+tags:
+  - css
+---
+
+This is the second article of my "How CSS Works" series, in which I dive into the internals of the CSS cascade algorithm and CSS specificity.

--- a/apps/website-sv/src/content/writing/how-tailwindcss-converted-me.md
+++ b/apps/website-sv/src/content/writing/how-tailwindcss-converted-me.md
@@ -1,0 +1,201 @@
+---
+title: How TailwindCSS converted me
+subtitle: 'Slowly but surely, utility-first CSS won me over.'
+date: 2020-12-17
+tags:
+  - css
+  - front-end
+---
+
+I'm _surprised_ I like [TailwindCSS](https://tailwindcss.com/). I tried it a couple years ago (pre-v1) and I remember that I couldn't stand this whole "utility-first" CSS thing.
+
+Instead, I dove headfirst into CSS-in-JS, trying out `styled-components`, `emotion`, and a few other libraries.
+
+For the past couple years, `emotion` has been easily my go-to approach for CSS. I've built some large apps using it, and I think it's fantastic if you're going with CSS-in-JS.
+
+However, I kept seeing all this Tailwind hype on Twitter. I had some people mention it on my [Twitch stream](https://www.twitch.tv/benjamindjohnson) as well as some coworkers talking about it. A couple months ago I figured it was time to give it another shot.
+
+I think Tailwind has unseated CSS-in-JS (and `emotion`) as my go-to CSS solution. I was pretty skeptical but it's finally converted me over. 🎉
+
+Here's some of my thoughts on _why_ I'm choosing Tailwind these days and why I'm now choosing it over CSS-in-JS.
+
+---
+
+## tl;dr ⏱
+
+Before we deep-dive, here's an executive summary. If you're pitching Tailwind to your team I would start here:
+
+- **Colocation of styles and markup.** While this feels like it violates "separation of concerns", it's views the _component_ as the unit of composition in front-end apps.
+- **Less naming fatigue.** Not being forced to name containers and wrapper frees you up to spend energy on more important problems.
+- **No JS runtime.** Save some kb of JS and send down regular ol' CSS instead. Don't forget to purge the unused Tailwind classes though!
+- **Scales better than you'd think.** Having things inline feels like a recipe for disaster, but Tailwind delivers on its promises if you give it a shot.
+- **Constraint-driven.** Having a design system with constraints built into it means that using Tailwind will often lead to more consistent, cleaner UIs. Especially if you're not a designer.
+
+---
+
+## The tradeoffs you make with Tailwind
+
+Since I was a skeptic about utility-first CSS, I'm going to start with the reasons I _didn't_ like Tailwind, and what's changed.
+
+Hopefully these line up with your concerns about Tailwind if you're on the fence. _(Or if you're advocating using Tailwind on your team and you're having struggles convincing team members.)_
+
+### wHaT aBOut sEpArAtIOn oF cOnCErns?
+
+When I learned programming, I was taught that markup (HTML), styles (CSS), and functionality (JS) should be split into separate files.
+
+After building some larger (and more complex) applications, I don't think "concerns" in front-end apps always map nicely to HTML, CSS, and JS files. Especially if you're using a framework.
+
+In React we put HTML in our JS files ([JSX](https://reactjs.org/docs/introducing-jsx.html)). [Vue's single-file components](https://v3.vuejs.org/guide/single-file-component.html#single-file-components) put HTML/CSS/JS in one `.vue` file.
+
+In modern web apps I think the _component itself_ is the "concern" we want to separate. It's not the styles vs the JS vs markup—they all work together to make up the self-contained component.
+
+As I've reflected on components being self-contained, I've grown more and more open to having styling directly in my markup. _(I've actually been doing this for a while via `emotion`'s `css` prop.)_
+
+Adam Wathan (Tailwind's creator) also has a fantastic article on [separation of concerns and utility CSS](https://adamwathan.me/css-utility-classes-and-separation-of-concerns/). If this is your main roadblock to trying out Tailwind I'd highly recommend giving it a read.
+
+### Ugly markup
+
+Another thing that I originally _hated_ with Tailwind was the explosion of classes into my HTML.
+
+It can be a bit jarring seeing that list of classes the first time you have to do some complex styling.
+
+```html
+<a
+	href="https://example.com"
+	className="inline-block text-xl font-medium text-black no-underline dark:text-white"
+>
+	<span className="lowercase">Link text</span>
+</a>
+```
+
+And unlike CSS-in-JS, you can't statically type the fields with TypeScript. Splitting the string of classes into multiple lines is also less than ideal.
+
+I'll admit, it took me a while to acclimate to this. However, I now think the single string of classes (in most cases) to be less messy than using a CSS-in-JS `css` prop. Tailwind's classes all fit into a single (albeit long) line while the `css` prop styles will do a single line per rule.
+
+And while having a `styled-component` results in less _markup code_, this comes with its own tradeoffs (you lose colocation of styles/markup to trim down lines of markup)
+
+### Big CSS file size
+
+When I had originally tried Tailwind the file size of the bundled CSS was a big concern. If I remember correctly, `purgecss` was not bundled with Tailwind so you had to set it up separately.
+
+> _If you're not familiar with `purgecss`, it's a `postcss` plugin that removes any CSS that isn't used._
+
+Now that `purgecss` comes built-in to `tailwind.config.js` keeping production files small is easy-peasy.
+
+The key thing to remember about `purgecss` is that it operates by finding string matches of classes in your code. This means that you can't do dynamic JS to build Tailwind classes since `purgecss` won't match them and will mark them for removal.
+
+Which brings me to the next trade-off of Tailwind...
+
+### Not as dynamic as CSS-in-JS
+
+Simply put, Tailwind is nowhere near as dynamic as CSS-in-JS. And that's a good thing.
+
+With CSS-in-JS, you have the full power of JavaScript (or TypeScript) as your preprocessor. Turns out, this is a double-edged sword.
+
+JS as a preprocessor can let you dynamically style based on data, create elegant "DRY" mixins, and get static typing.
+
+The thing is, a lot of times we don't need that much power. We just need to flip a couple styles based on our button is `primary` or `secondary`.
+
+I've found I can get 90% of the dynamic styles I need by conditionally applying classes with [`clsx`](https://github.com/lukeed/clsx) (or [`classnames`](https://github.com/JedWatson/classnames)). For the other 10%, a combination of inline styles, custom CSS, and CSS variables is enough.
+
+If you have super dynamic styles, you don't _have_ to exclude CSS-in-JS to use Tailwind. You can use both in an app, or use the [`tailwind-babel-macro`](https://github.com/bradlc/babel-plugin-tailwind-components) to generate CSS-in-JS styles.
+
+### Good for prototyping and small projects, but it won't scale.
+
+Lastly, my common reply whenever Tailwind got brought up used to be "I think it looks _interesting_, but I wouldn't pick it if the project needs to _scale_".
+
+I thought it was only a good tool for prototyping and smaller apps.
+
+**I was wrong.**
+
+Now that I've built a few apps with Tailwind, I think I can say that it has the qualities I'd look for when searching for a "robust" styling approach.
+
+In fact, I'd say that Tailwind not only makes scaling your styles _possible_, it might even make it _simpler_.
+
+_I couldn't find a list of companies using Tailwind at the time of writing. But check any comments section, Hacker News, Twitter, etc and you'll find anecdotal evidence of people shipping production-grade apps with it._
+
+## Some additional benefits of Tailwind
+
+Now that we've gone through my past blockers to using Tailwind, I wanna look at a couple extra benefits I think using Tailwind offers.
+
+### Colocation of styles & markup
+
+We already touched on this a little bit when talking about "separation of concerns" but it bears repeating. Having styles and markup in a single file initially _sounds_ bad, but it carries numerous benefits:
+
+- Deleting HTML (or JSX) automatically deletes its associated CSS.
+- Less nasty import paths (bye, bye, `../../../../`)
+- Smaller, more manageable directory structure.
+
+Note that colocation of styles and markup is possible in CSS-in-JS via thins like `emotion`'s `css` prop and `theme-ui`'s `sx` prop.
+
+I'm not the first to extol the pluses of colocation—check out [this article by Kent C. Dodds](https://kentcdodds.com/blog/colocation) on how colocation can help software projects stay maintainable.
+
+### Less naming fatigue
+
+Naming things is hard. After all, it _is_ one of the ["two hard problems"](https://martinfowler.com/bliki/TwoHardThings.html) in software development.
+
+It's critical that we learn to give things meaningful names when we're building software projects.
+
+But we don't have to name **every. single. thing.** We can pick and choose our battles.
+
+I experienced this naming fatigue when using CSS-in-JS libraries like `styled-components` as well as in raw CSS using [BEM](https://css-tricks.com/bem-101/) naming conventions.
+
+The problem is that you have to create a meaningful name in order to apply styles to any HTML tag. This adds significant mental overhead—after all, there's only so many variations of `Container` and `Wrapper` out there. 😅
+
+I'm not saying that you never name styles—you'll probably want to abstract things into components and give them meaningful names. But it's liberating to not be _required_ to come up with a name when all you want is a little `padding` on a `div`.
+
+### Built-in design system
+
+Tailwind's approach to CSS centers largely around _design systems_ and generating _design system tokens_. Tailwind sets up a design system and corresponding CSS classes for you out of the gate. However if you (or your designer) need custom values you can customize the generated CSS via `tailwind.config.js`
+
+For example, instead of allowing you to pick any pixel (or `rem`!) value for margin, Tailwind sets up classes like `.m-0` (`0`), `.m-4` (`1rem`), `.m-6` (`1.5rem`). Each number on the `m` scale corresponds to a predetermined value.
+
+While it seems like having full control over the pixel values would let you achieve pixel perfection, it turns out having _some constraints_ forces you to choose the nearest value from your design system. This generally leads to a more unified design.
+
+This _can_ be done in CSS-in-JS or raw CSS/SCSS, but you'll have to create the design system tokens yourself, which can take a good deal of time and effort (`theme-ui` does create tokens for you by default). You'll also have to enforce design system in usage in every PR to make sure that people don't sneak hard-coded pixel values in.
+
+### Framework agnostic
+
+As a whole, CSS-in-JS tends to favor the React ecosystem. While there are a few framework agnostic CSS-in-JS libraries (`emotion` included), most are geared towards the React community.
+
+For example, `styled-components` only works with React (to my knowledge), and I'd consider `emotion` to be React-first (most of the documentation assumes you're using JSX).
+
+In contrast, Tailwind is built on top of PostCSS and integrates seamlessly into any front-end project. It's nice knowing that knowledge of this tool can be reused in a project using Vue, Svelte, Angular, or even raw HTML.
+
+### Less build setup
+
+Tailwind definitely involves _some_ build setup, but much less than a lot of CSS-in-JS libraries.
+
+If you're building a moderately large project, the CSS won't be the _only_ thing you have to setup. Chances are you'll have to integrate your solution along with stuff like TypeScript, Babel, ESLint, Jest, and server-rendering.
+
+Getting all of these to play nice in the sandbox can make you tear your hair out. I've spent multiple _days_ getting a CSS-in-JS setup working properly with full server-rendering, TypeScript, ESLint, and JEst support. It's not pleasant.
+
+Although Tailwind requires a configuration file, they make it easy to get up and running. You can run `npx tailwind init` and they'll generate a config file with all of the defaults applied! 🎉
+
+This lets you spend less time setting up your project and more time building your project.
+
+### No runtime JavaScript
+
+This is a big win for Tailwind over CSS-in-JS. Since Tailwind is a CSS utility framework, it doesn't add any JS to your production bundle.
+
+In contrast we have CSS-in-JS which ships with a runtime to parse the style objects into valid CSS, generate classes, and insert those into the `head` of the document.
+
+`@emotion/react`'s runtime is about 10kb (gzip + min) and `styled-components` ships with about 12kb of JS (gzip + min). And that's before you write any of your own code.
+
+Tailwind doesn't ship any runtime JS, which creates a little more space on the main thread for everything else in your app as well as faster load times for your users.
+
+> ⚠️ _If you forget to use `purgecss` you might accidentally send **the entire Tailwind CSS** in your production code. This would actually be worse since Tailwind v2 is about 290kb gzipped! [You can read more about purging CSS here](https://tailwindcss.com/docs/optimizing-for-production)_.
+
+---
+
+## Some closing thoughts
+
+Tailwind is far from being a **perfect** CSS solution, but I think it's a **good** one. Who knows? I might be writing another post like this about some other technology in a year or so. 😅
+
+That said, Tailwind is controversial in the front-end community because it throws so much "conventional wisdom" out the door. And yet people using Tailwind are extremely satisfied with it—head over to any public forum and you'll see people gushing over Tailwind.
+
+There is no silver bullet when it comes to software tools. There's only pragmatically evaluating the pros and cons of each tool, and explicitly choosing the tradeoffs that seem best for your given use-case.
+
+Right now, Tailwind is one of those tools—I like the tradeoffs it makes and think it will prove extremely useful as I continue to build web apps.
+
+Feel free to reach out with any feedback or comments! You can find me on [Twitter](https://twitter.com/benjamminj) and [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/). If you see a typo or if there's a significant mistake in what I've written, please open a [PR](https://github.com/benjamminj/portfolio/tree/main/writing) to edit this article. Thanks for reading!

--- a/apps/website-sv/src/content/writing/learning-a-new-codebase.md
+++ b/apps/website-sv/src/content/writing/learning-a-new-codebase.md
@@ -1,0 +1,43 @@
+---
+title: 'Learning a New Codebase: The Good, The Bad, and The Ugly'
+description: If getting up to speed with a codebase of thousands and thousands of lines sounds intimidating, remember that it is a long process that greatly pays off.
+date: 2017-08-28
+---
+
+At one point or another — whether you’re a seasoned pro or just getting started — you’re going to have to learn a new codebase. It’s always easier to know the code inside and out when you’ve crafted every line yourself, but what about when you’re hopping into a new project, potentially with thousands of lines? You want to get up to speed quickly and start providing real contributions, but how can you do that if you don’t understand how the application works?
+
+I’ll be honest, I’m no seasoned veteran, but I have had to grok a couple large codebases in the past year that I’ve spent on this programming journey. To top it off, I just started a new job with a few new codebases, so this is all fresh in my head.
+
+## 1. Read, Read, Read
+
+The fact is simple: to understand what the code in your codebase is doing, you are going to have to read it.
+
+Read everything — unit tests, documentation, and the code itself. Read it slowly, line by line, and figure out what it’s doing. Read as much of it as you can, as often as you can.
+
+Just by reading the code, you’ll automatically start to see a few things—styling, naming conventions, organizational structures, etc. Pretty soon you’ll also have a much better understanding of what the code actually does, making it way easier for you to make changes. But more on that later.
+
+Oftentimes, codebases are extremely large—over a few thousand lines—and you simply won’t have the luxury of sitting down to read the whole codebase from start to finish. I’ve only been able to do this on one occasion, but the application was about 300 lines of code.
+
+Instead of trying to sit down for a full reading, choose a starting place (usually whatever you’re working on at the moment) and figure out how it works internally. Then follow that single module through the rest of the application, seeing where and how it is used. If the codebase is broken up into understandable chunks, understanding how a single module works will greatly increase you knowledge of the whole application.
+
+## 2. Ask questions
+
+However, simply reading code isn’t enough. Ultimately, you have to understand the code, and sometimes this mean asking questions.
+
+Ask yourself questions when you’re reading. Many times, you can find the answers to your questions by either reading more or doing a little online research. If after that you don’t understand something, don’t be afraid to ask the engineers that wrote it.
+
+Ideally many questions will be answered in the code’s documentation, but sometimes this isn’t the case. When there isn’t documentation or comments to explain unclear code, you will have to either find the answers yourself or simply ask for them.
+
+## 3. Don’t be afraid to make changes.
+
+One of the best ways to find out stuff works is to break things. You make a change, perhaps a new feature, perhaps refactoring some code, and you break the application, or now all of the tests are failing. That’s good — now you have a better understanding of how that section of code works.
+
+This strategy only works to some degree. Obviously you can’t just break things or make changes at random, simply hoping that they’ll work. However, if your team has a peer review system of CI/unit tests, you can make changes confidently, knowing that when you break stuff it will never make it to production code.
+
+Life is too short to be paralyzed by fear of breaking things. Rather than being afraid of error messages, understand that each time you break something is an chance to learn something new about how the codebase works. Once you’ve fixed it (even if that’s just rolling back your changes), finding our why/how you broke the application is crucial to understanding how that specific part of the code interacts with the entire codebase.
+
+## Conclusion
+
+If getting up to speed with a codebase of thousands and thousands of lines sounds intimidating to you, just remember that it is a long process with great payoff.
+
+To some degree, it’s a process that you never complete, since the codebase changes rapidly as you and your team work on it. There will always be new code written by other developers that you need to read and understand. That’s part of the thrill of working in software development — the codebase is a living, changing organism, and you are always learning new things about it.

--- a/apps/website-sv/src/content/writing/loading-dots-icon.md
+++ b/apps/website-sv/src/content/writing/loading-dots-icon.md
@@ -1,0 +1,118 @@
+---
+title: Loading dots icon
+description: AKA "thinking bubbles". Created with React, Tailwind, and TS
+date: 2022-04-10
+tags:
+  - recipes
+  - react
+  - typescript
+  - front-end
+  - css
+---
+
+```tsx
+// loading-dots.tsx
+
+// Note: these types can commonly go in a central file of utility types for
+// all SVG icons, or can be baked into your component lib if you've made one for your
+// icons
+export type IconSize = 'sm' | 'base' | 'lg';
+
+export type SvgIconProps = {
+	size?: IconSize;
+};
+
+const iconSizeClasses = {
+	sm: 'h-4',
+	base: 'h-6',
+	lg: 'h-6'
+};
+
+export const LoadingDots = ({
+	size = 'base',
+	title = 'Loading'
+}: SvgIconProps & { title?: string }) => {
+	const className = iconSizeClasses[size];
+	return (
+		<svg viewBox="0 0 60 30" xmlns="http://www.w3.org/2000/svg" className={className} role="img">
+			<title>{title}</title>
+			<g className="fill-current">
+				<circle
+					cx="12"
+					cy="15"
+					r="6"
+					className="animate-pulse animation-delay-[0ms] animation-duration-[1.5s] opacity-0"
+				/>
+				<circle
+					cx="30"
+					cy="15"
+					r="6"
+					className="animate-pulse animation-delay-[200ms] animation-duration-[1.5s] opacity-0"
+				/>
+				<circle
+					cx="48"
+					cy="15"
+					r="6"
+					className="animate-pulse animation-delay-[400ms] animation-duration-[1.5s] opacity-0"
+				/>
+			</g>
+		</svg>
+	);
+};
+```
+
+And in order to get those `animation-duration` and `animation-delay` classes, we need to do a tiny bit of tinkering with the `tailwind.config.js`
+
+```js
+// tailwind.config.js
+
+const plugin = require('tailwindcss/plugin');
+
+module.exports = {
+	// theme, content, etc.
+	plugins: [
+		plugin(({ addUtilities, matchUtilities, theme }) => {
+			matchUtilities(
+				{
+					'animation-duration': (value) => ({
+						animationDuration: value
+					})
+				},
+				{ values: theme('transitionDuration') }
+			);
+
+			matchUtilities(
+				{
+					'animation-delay': (value) => ({
+						animationDelay: value
+					})
+				},
+				{ values: theme('transitionDelay') }
+			);
+		})
+	]
+};
+```
+
+## Context
+
+This component allows you to make the fancy "loading dots" or "thinking bubbles" component. I commonly find myself reaching for an icon like this, yet it's one that's not as common in icon libraries.
+
+I'm often been using [TailwindCSS](https://tailwindcss.com/) to style my apps, so I included Tailwind classes in this snippet instead of the raw CSS.
+
+## How it works
+
+With a bit of custom SVG we can create this icon from scratch without having to whip out a design tool. Since this icon does not have complex paths or lines, we can use the SVG `circle` element to get our three dots, and the rest is fiddling with the `viewBox`, `cx`, `cy`, and `r` to get the circles exactly where we'd like them.
+
+In order for screen readers to read the icon properly, we also need to add a `title` attribute. Since this is commonly used as a standalone loading indicator `title` is included in the icon props.
+
+## Usage
+
+```tsx
+// All the HTML attributes permitted on `button`, as well as a `loading` flag
+type ButtonProps = JSX.IntrinsicElements['button'] & { loading?: boolean };
+
+const Button = ({ loading = false }: ButtonProps) => {
+	return <button>{loading ? <LoadingDots /> : 'Save'}</button>;
+};
+```

--- a/apps/website-sv/src/content/writing/lodash-set-vanilla-js.md
+++ b/apps/website-sv/src/content/writing/lodash-set-vanilla-js.md
@@ -1,0 +1,94 @@
+---
+title: Lodash `set` in raw JavaScript
+subtitle: Skip the extra dependency and use this small utility from scratch.
+date: 2022-03-17
+tags:
+  - from-scratch
+  - typescript
+  - javascript
+  - recipes
+---
+
+```tsx
+/**
+ * This is a replacement for lodash _.set(), it contains core functionality but
+ * perhaps skips some edge cases.
+ */
+export const set = <T extends Record<string, unknown> = Record<string, unknown>>(
+	obj: Record<keyof T, unknown>,
+	path: string | string[],
+	value: unknown
+): T => {
+	// Contains all characters that are not `.`, `[`, or `]`
+	const validPathCharactersRegex = /([^[.\]])+/g;
+	const pathArray = Array.isArray(path) ? path : path.match(validPathCharactersRegex);
+
+	if (!pathArray) return obj;
+
+	let nestedObj = obj;
+	for (let i = 0; i < pathArray.length; i++) {
+		let key: string | number = pathArray[i];
+
+		// First, set the item to an object/array, if it's not the last we want
+		// to make a nested path.
+		if (nestedObj[key] === undefined) {
+			const isIndex = isNaN(Number(pathArray[i + 1]));
+			nestedObj[key as keyof T] = isIndex ? {} : [];
+		}
+
+		// If it's the last in the list, set the item to the value
+		if (i === pathArray.length - 1) {
+			nestedObj[key as keyof T] = value;
+		}
+
+		nestedObj = nestedObj[key];
+	}
+
+	return obj;
+};
+```
+
+## Context
+
+`set` is a drop-in replacement for Lodash's `_.set` method. It allows you to set the value at a given path. If the path doesn't exist yet, it also creates the path for you! (woohoo, no `undefined` exceptions!).
+
+I find many of my projects only use a few Lodash methods. Sometimes it's just better to just copy them over into the codbase "from scratch" (and save a dependency in the process!). While this `set` method doesn't cover _all_ the edge cases Lodash does, it covers the primary workflows.
+
+This snippet of `set` also is ~200 bytes, so it's super lightweight 😅
+
+## Usage
+
+```tsx
+import { set } from './set';
+
+const obj = { a: 1 };
+
+// set a path deep in the object
+set(obj, 'b.c.d', 3);
+console.log(obj.b.c.d); // 3
+
+// you can also set array items
+set(obj, 'b.e[0].f', 4);
+console.log(obj.b.e); // [{ f: 4 }]
+```
+
+## Tests
+
+```ts
+import { set } from './set';
+
+test('should allow setting nested paths', () => {
+	const obj = {};
+	set(obj, 'a.b.c', 1);
+	// @ts-expect-error
+	expect(obj.a.b.c).toEqual(1);
+});
+
+test('should allow setting nested array paths', () => {
+	const obj = {};
+	set(obj, 'a.b[0].c', 1);
+	set(obj, 'a.b[1].c', 2);
+	// @ts-expect-error
+	expect(obj.a.b).toEqual([{ c: 1 }, { c: 2 }]);
+});
+```

--- a/apps/website-sv/src/content/writing/march-2022-update.md
+++ b/apps/website-sv/src/content/writing/march-2022-update.md
@@ -1,0 +1,27 @@
+---
+title: March 2022 Update
+date: 2022-04-01
+tags:
+  - updates
+  - writing
+---
+
+## Trying something new 🧪
+
+I'm gonna try writing some of these smaller updates on a (hopefully) monthly basis. With new responsibilities (more on that coming soon!) I've found that I have less and less time to write here.
+
+That said, I'm not gonna beat myself up if I miss an update. Sometimes life happens and the website won't be updated, and that's ok.
+
+## New family member 👶
+
+![Ian Johnson](https://user-images.githubusercontent.com/20060118/161328996-a5ab7cb7-4ab6-467d-91b5-17506d239f8b.JPG)
+
+On March 19 my wife and I welcomed Ian to our family! We love this little guy so much and have cherished each sleep-deprived moment since his arrival.
+
+I've been on parental leave since, and am _loving it_. I'm incredibly grateful to [Panther Labs](https://panther.com) for this time to bond with my family and adjust to my new job as Dad.
+
+## Miscellaneous updates 🤓
+
+- Been playing with [Remix](https://remix.run/) quite a bit lately, and loving it. I'm especially fond of the focus on _fundamentals_ and _simplicity_. It certainly feels like a breath of fresh air.
+- Just finished reading [Kill it with Fire](https://nostarch.com/kill-it-fire) by Marianne Bellotti. I highly recommend it, especially if you work on any software that needs to live more than a couple months.
+- Per the above announcement, most of my energy has gone into learning my new role as Dad, and adjusting to life as a new parent 💕

--- a/apps/website-sv/src/content/writing/mocking-fetch.md
+++ b/apps/website-sv/src/content/writing/mocking-fetch.md
@@ -1,0 +1,238 @@
+---
+title: Mocking the fetch API with Jest
+description: Why should we mock the network? We'll take a look at why it's important to mock window.fetch and a couple methods we can use in our test suites.
+draft: false
+date: 2019-04-26
+lastUpdated: 2020-12-30T00:00:00.000Z
+image:
+  url: 'blue-paint-swirls.jpg'
+  alt: 'Abstract swirling colors of blue and red'
+tags:
+  - testing
+  - jest
+  - javascript
+---
+
+> [!WARNING]
+>
+> **Note:** I've left the bulk of this article untouched for posterity, but I wouldn't recommend mocking
+> `fetch` using this method anymore (as of June 2024).
+>
+> Personally, I'd go with [mock-service-worker](https://mswjs.io/) if you need to mock network requests in your unit tests.
+
+In this tutorial we are going to look at mocking out network calls in unit tests. Specifically we are going to dive into mocking the `window.fetch` API. If you're unfamiliar with the `fetch` API, it's a browser API that allows you to make network requests for data (you can also read more about it [here](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)). We'll look at _why_ we would want to mock `fetch` in our unit tests, as well as a few different mocking approaches that we can use.
+
+## Why would we want to mock out network calls?
+
+Before we go straight into mocking the `fetch` API, I think it's important that we take a step back and ask ourselves _why_ we would want to mock it. Otherwise, we'll just know how to write the mock instead of actually knowing what value it provides.
+
+One of the main reasons we have for mocking `fetch` is that this is how our app interacts with the outside world. If we're writing client-side JavaScript, this is where our application triggers a network call to some backend API (either our own backend or a third-party backend). And if we're writing server-side JavaScript (using `fetch` via a package like `node-fetch`) this is where our server talks to _another_ server outside of itself.
+
+If we simply let `fetch` do its thing without mocking it at all, we introduce the possibility of flakiness into our tests. A unit test would be considered to be _flaky_ if it _does not always produce the exact same output given the same inputs_. The following example will always produce the same output.
+
+```js
+function add(a, b) {
+	return a + b;
+}
+
+// This is the test for the `add` function
+describe('add', () => {
+	test('adds 2 numbers', () => {
+		expect(add(1, 2)).toEqual(3);
+	});
+});
+```
+
+However, when testing code that uses `fetch` there's a lot of factors that can make our test fail——and many of them are not directly related to input of the function. What happens if your computer is disconnected from the internet? What happens to your test suite if you're working on an airplane (and you _didn't_ pay for in-flight wifi)? What happens when that third-party API is down and you can't even merge a pull request because all of your tests are failing?
+
+Secondly, mocking `fetch` allows us to exert fine-grained control over what data our app receives "from the API".
+
+If we're able to replace all network calls with reliable data, this also means that we can replicate scenarios in our testing environments that would be difficult to reproduce if we were hitting a real API. While it might be difficult to reproduce what happens on the client-side when the API returns 500 errors (without actually breaking the API), if we're mocking out the responses we can easily create a test to cover that edge case.
+
+## Mocking the fetch API
+
+So, now that we know _why_ we would want to mock out `fetch`, the next question is _how_ do we do it? There's a few ways that we'll explore. Each one has unique tradeoffs——it's difficult to say whether one is "better" or "worse" since they both achieve the same effect.
+
+### Method #1: Replace the global `fetch` with our mocked `fetch`
+
+The first way that we can go about mocking `fetch` is to actually _replace the `global.fetch`_ function with our own mocked `fetch` (If you're not familiar with `global`, it essentially behaves the exact same as `window`, except that it works in both the browser _and_ Node. That way you don't have to change where you're getting `fetch` from per environment. You can read more about `global` [here](TK link)).
+
+It's not usually a good idea to replace things on the `global`/`window` object! True to its name, the stuff on `global` will have effects on _your entire application_. Every time that you add stuff to the `global` namespace you're adding complexity to the app itself and risking the chance of naming collisions and side-effects.
+
+However, in the testing environment we can get away with replacing `global.fetch` with our own mocked version——we just have to make sure that after our tests run we clean our mocks up correctly. That way we don't accidentally replace `fetch` for a separate test suite (which might call a different API with a different response).
+
+Here's what it would look like to mock `global.fetch` by replacing it entirely.
+
+```js
+// This is the function we'll be testing
+async function withFetch() {
+	const res = await fetch('https://jsonplaceholder.typicode.com/posts');
+	const json = await res.json();
+
+	return json;
+}
+
+// This is the section where we mock `fetch`
+const unmockedFetch = global.fetch;
+
+beforeAll(() => {
+	global.fetch = () =>
+		Promise.resolve({
+			json: () => Promise.resolve([]),
+		});
+});
+
+afterAll(() => {
+	global.fetch = unmockedFetch;
+});
+
+// This is actual testing suite
+describe('withFetch', () => {
+	test('works', async () => {
+		const json = await withFetch();
+		expect(Array.isArray(json)).toEqual(true);
+		expect(json.length).toEqual(0);
+	});
+});
+```
+
+Let's walk through this example! 😅
+
+First, we have the actual `withFetch` function that we'll be testing. Usually this would live in a separate file from your unit test, but for the sake of keeping the example short I've just included it inline with the tests. `withFetch` doesn't really do much——underneath the hood it hits the [placeholderjson](https://jsonplaceholder.typicode.com/) API and grabs an array of posts. This array in the API response is 100 posts long and each post just contains dummy text.
+
+Next, let's skip over the mocking portion for a sec and take a look at the unit test itself. The unit test calls the `withFetch` function and waits for it to resolve (since it's an `async` function we use `await` to pause execution until `withFetch` resolves). Then we assert that the returned data is an array of 0 items. If we actually hit the [placeholderjson](https://jsonplaceholder.typicode.com/) API and it returns 100 items this test is guaranteed to fail!
+
+This test is setup to make sure that we actually mock `fetch`. In order to make our test pass we will have to replace the `fetch` with our own response of 0 items.
+
+Finally, we have the mock for `global.fetch`. As a quick refresher, the mocking code consists of three parts:
+
+```js
+// Part 1
+const unmockedFetch = global.fetch;
+
+// Part 2
+beforeAll(() => {
+	global.fetch = () =>
+		Promise.resolve({
+			json: () => Promise.resolve([]),
+		});
+});
+
+// Part 3
+afterAll(() => {
+	global.fetch = unmockedFetch;
+});
+```
+
+In the first part we store a reference to the _actual function_ for `global.fetch`. Since we'll be mocking `global.fetch` out at a later point we want to keep this reference around so that we can use it to cleanup our mock after we're done testing.
+
+The second part consists of the actual `fetch` mock. The important thing to note is that the mocked `fetch` API _must be API-compatible_ with the real `fetch` API. `fetch` returns a resolved `Promise` with a `json` method (which also returns a `Promise` with the JSON data). So we need to do the same thing inside our mock. In order to mock something effectively you must understand the API (or at least the portion that you're using).
+
+You don't need to rewrite the entire functionality of the module—otherwise it wouldn't be a mock! You can mock the pieces that you're using, but you do have to make sure that _those_ pieces are API compatible.
+
+However, instead of returning 100 posts from the `placeholderjson` API, our `fetch` mock just returns an empty array from its `json` method. You could put anything here——you could put the full 100 posts, have it "return" nothing, or anything in-between! By having control over _what_ the `fetch` mock returns we can reliably test edge cases and how our app responds to API data without being reliant on the network!
+
+Finally, the last portion of our mock is to restore the actual `global.fetch` to its former glory after all the tests have run. `afterAll` is a hook provided by `jest` that runs at the end of the test suite (just like `beforeAll` runs before the test suite), so we use it to set `global.fetch` back to the reference that we stored.
+
+This is important if you're running multiple test suites that rely on `global.fetch`. If you don't clean up the test suite correctly you could see failing tests for code _that is not broken_. What essentially happens is the subsequent test suites use the mock from _the earlier test suite_ and they're not expecting the same response (after all, that mock might be in an entirely different file 😱).
+
+Furthermore, your tests might not run in the exact same order each time so it's never a good idea to have tests share state. Instead, try to think of each test in isolation——can it run at any time, will it set up whatever it needs, and can it clean up after itself?
+
+### Method #2: Use `jest.spyOn` to do all the hard work for us
+
+Now that we've looked at one way to successfully mock out `fetch`, let's examine a second method using [Jest](https://jestjs.io/). If you haven't used [Jest](https://jestjs.io/) before, it's another testing framework built and maintained by the engineers at Facebook.
+
+One of my favorite aspects of using Jest is how simple it makes it for us to mock out code—even our `window.fetch` function! 🙌
+
+While the first example of mocking `fetch` would work in any JavaScript testing framework (like Mocha or Jasmine), this method of mocking `fetch` is specific to Jest. Here's what it would look like to change our code from earlier to use Jest to mock `fetch`.
+
+```diff
+-// Part 1
+-const unmockedFetch = global.fetch
+-
+-// Part 2
+-beforeAll(() => {
+-  global.fetch = () =>
+-    Promise.resolve({
+-      json: () => Promise.resolve([]),
+-    })
+-})
+-
+-// Part 3
+-afterAll(() => {
+-  global.fetch = unmockedFetch
+-})
+
++const fetchMock = jest
++  .spyOn(global, 'fetch')
++  .mockImplementation(() => Promise.resolve({ json: () => Promise.resolve([]) }))
+```
+
+Jest provides a `.spyOn` method that allows you to listen to all calls to any method on an object. To use `jest.spyOn` you pass the object containing the method you want to spy on, and then you pass the _name of the method as a string_ as the second argument.
+
+Jest's `spyOn` method returns a _mock function_, but as of right now we _haven't replaced the fetch function's functionality_. To do that we need to use the `.mockImplementation(callbackFn)` method and insert what we want to replace `fetch` with as the `callbackFn` argument. We can simply use the same `fetch` mock from before, where we replace `fetch` with `() => Promise.resolve({ json: () => Promise.resolve([]) })`.
+
+If you're not familiar with test spies and mock functions, the TL;DR is that a spy function _doesn't change any functionality_ while a _mock function replaces the functionality_. Test spies let you record all of the things that function was called. Later you can assert things based on what arguments the spy function received. For example, we could assert that `fetch` was called with `https://placeholderjson.org` as its argument:
+
+```js
+const fetchMock = jest
+	.spyOn(global, 'fetch')
+	.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+
+describe('withFetch', () => {
+	test('works', async () => {
+		const json = await withFetch();
+
+		// highlight-start
+		expect(fetchMock).toHaveBeenCalledWith('https://jsonplaceholder.typicode.com/posts');
+		// highlight-end
+
+		expect(Array.isArray(json)).toEqual(true);
+		expect(json.length).toEqual(0);
+	});
+});
+```
+
+The cool thing about this method of mocking fetch is that we get a couple extra things for free that we don't when we're replacing the `global.fetch` function manually. First off, instead of managing `beforeAll` and `afterAll` ourselves, we can simply use Jest to mock out the `fetch` function and Jest will handle _all of the setup and teardown for us_! Secondly, we make it a lot easier to spy on what `fetch` was called with and use that in our test assertions.
+
+## Customizing the mocked response for individual tests
+
+In addition to being able to mock out `fetch` for a single file, we also want to be able to customize _how `fetch` is mocked for an individual test_.
+
+The main reason that we want to be able to do this boils down to what the module we're testing is responsible for. If we have a module that calls an API, it's usually also responsible for dealing with a handful of API scenarios.
+
+For example, we know what this module does when the response is 0 items, but what about when there are 10 items? 100 items? What happens if the data is paginated or if the API sends back a 500 error?
+
+Our code that deals with external APIs has to handle a ton of scenarios if we want it to be considered "robust", but we also want to set up automated tests for these scenarios. Getting the API to return a 500 error might actually be a little difficult if you're manually testing from the front-end, so having a mocked `fetch` allows us to run our API handling code with every unit test run.
+
+In order to mock `fetch` for an individual test, we don't have to change much from the previous mocks we wrote! As a first step, we can simply move the mocking code _inside of the test_.
+
+```js
+describe('withFetch', () => {
+	test('works', async () => {
+		// highlight-start
+		const fetchMock = jest
+			.spyOn(global, 'fetch')
+			.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+		// highlight-end
+
+		const json = await withFetch();
+		expect(fetchMock).toHaveBeenCalledWith('https://jsonplaceholder.typicode.com/posts');
+
+		expect(Array.isArray(json)).toEqual(true);
+		expect(json.length).toEqual(0);
+	});
+});
+```
+
+And that's it! Now, if we were to add another test, all we would need to do is re-implement the mock _for that test_, except we have complete freedom to do a _different_ `mockImplementation` than we did in the first test.
+
+The big caveat of mocking `fetch` for each individual test is there is considerably more boilerplate than mocking it in a `beforeEach` hook or at the top of the module. However, if I need to switch how `fetch` responds for individual tests, a little extra boilerplate is much better than skipping the tests and accidentally shipping bugs to end users.
+
+---
+
+## Conclusion
+
+Mocking `window.fetch` is a valuable tool to have in your automated-testing toolbelt—it makes it incredibly easy to recreate difficult-to-reproduce scenarios and guarantees that your tests will run the same way no matter what (even when disconnected from the internet).
+
+If you enjoyed this tutorial, I'd love to connect! As always, you can [follow me on Twitter](https://twitter.com/benjamminj) or [connect with me on LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) to hear about new blog posts as I publish them.

--- a/apps/website-sv/src/content/writing/moving-away-from-mdx.md
+++ b/apps/website-sv/src/content/writing/moving-away-from-mdx.md
@@ -1,0 +1,38 @@
+---
+title: Moving away from MDX
+description: At least for blogging, plain markdown is less frictionG
+date: 2022-01-17
+tags:
+  - writing
+---
+
+I just [removed MDX files from my blog](https://github.com/benjamminj/portfolio/pull/162).
+
+I've left the MDX parser for now. But going forward, authoring in `.mdx` is gonna be the _exception_, not the _rule_. I might strip the MDX parser out entirely in favor a simpler parser, we'll see.
+
+This move has been something I've been contemplating for about a month now. Here's a few reasons why:
+
+## Why not MDX?
+
+In short, MDX is loaded with cool functionality, but it didn't actual problems in my authoring workflow. In fact, I felt like the added complexity created _more_ problems for me.
+
+- **Plain markdown is enough for me to express myself.** I didn't need all the bells and whistles of MDX. I don't have a lot of interactive demos or custom widgets when writing.
+- **Less constraints = more decisions.** I found the limitless possibilities of MDX to be paralyzing while writing. Instead of focusing on capturing my _thoughts_, I was stuck with questions like "should this be a `Callout` or a `blockquote`?" For my highly-distractable mind (see: [ADHD](https://www.additudemag.com/adhd-in-adults/)), this equals major friction while writing.
+- **Markdown is more portable.** I've been toying with the idea of separating my content from my website's code. Whether that's just a separate repository, something like Notion, or a real CMS, Markdown presents a much easier path forward. Most external tools (like Notion / [Bear](https://bear.app/)) even support a "export as markdown" feature!
+
+In short, I'm ditching MDX because I don't need the extra functionality it provides, and I lose a lot by having another complex tool in my build pipeline.
+
+## When should you reach for MDX?
+
+MDX isn't bad, just wasn't the right choice for my personal blog. Which begs the question, _**"When is MDX the right choice?"**_.
+
+MDX is great if you have highly interactive demos as part of your content. You can easily colocate the demos next to the content and weave static and dynamic fluidly.
+
+It's also great if your content is more flexible than plain Markdown allows. For example, you have a lot of different layouts or widgets.
+
+Finally, MDX is a fantastic choice for documenting component libraries. In this case, you're weaving static content (talking about components) with interactive (embedding the components themselves).
+
+## Extra reading
+
+- [Shortcodes vs MDX](https://www.swyx.io/shortcodes-vs-mdx-3d4e/) - This article largely sums up my sentiments about MDX — at the moment, I think simple markdown + shortcodes probably makes more sense.
+- [Josh Comeau's blog](https://www.joshwcomeau.com/blog/how-i-built-my-blog/) - This blog heavily uses MDX to build a fully-interactive reading experience. It's a great example of a use case where MDX makes total sense.

--- a/apps/website-sv/src/content/writing/my-experience-at-thinkful.md
+++ b/apps/website-sv/src/content/writing/my-experience-at-thinkful.md
@@ -1,0 +1,39 @@
+---
+title: My experience at Thinkful, ~5 years later
+description: What I learned in the bootcamp, and what I didn't.
+date: 2021-12-09
+tags:
+  - bootcamps
+  - career
+  - job-searching
+---
+
+I'm trying a new thing! When I get a question more than a couple times, it goes into the backlog of articles I need to write! Sadly, this backlog grows longer every week, maybe someday I'll run out of article ideas! 😱
+
+As a grad of Thinkful, I often get asked about my experience there -- did I like it and was it worth the tuition? If you're considering Thinkful (or a bootcamp in general), I hope this article helps you as you consider some really large decisions about learning programming.
+
+## tl;dr
+
+Thinkful was a great choice for me at the time I attended -- it fit _what I needed_. But make sure it fits what _you_ need if you're considering attending there, everything I write here was 5 years ago!
+
+## Why I attended Thinkful
+
+It's really important to choose a learning path that suits _your_ needs. For me, Thinkful fit the bill for a few reasons:
+
+- **Remote-first.** Thinkful is primarily a remote bootcamp, and I didn't want to be driving into in-person classes. Remote work was a big reason I was interested in getting into the software industry, even before COVID-19.
+- **Affordable.** Thinkful was more affordable than the other bootcamps that I looked at, and their billing structure allowed me to finance it with a loan and pay it slowly. I couldn't afford to do a CS degree as I had just graduated with a music degree a few years earlier (also time, 4 years is a long time).
+- **Part-time.** Thinkful had part-time (20h / week, 6 months) and a full-time (40h / week, 3 months) courses when I attended. Attending part-time allowed me to work as a valet and continue paying rent while I changed careers.
+- **Self-paced with mentorship.** The program I attended was mostly self-paced -- you met 1-on-1 with a mentor 3x per week. Mentors were usually senior engineers working for Thinkful as a side-gig, so they had real industry experience.
+- **Career services.** At the time, Thinkful offered a robust career services branch _after you graduated_. You met with a career mentor 1x per week, and if Thinkful couldn't place you in a full-time job/internship within 6 months they would refund your tuition. Lots of bootcamps offer this today, but back then it wasn't as common.
+
+## My experience
+
+Overall, I had a great experience at Thinkful! The self-paced curriculum paired with frequent lessons with my mentor worked well for me. Coming from a music background, learning to code felt like learning an instrument -- you had lessons with a teacher and homework to do between lessons.
+
+Another thing that allowed me to learn deeply was taking the course at a part-time pace. I was only expected to do ~20 hours of work per week, but I probably ended up coding for ~30 hours per week. This gave me some extra time to get lost in rabbit holes and _be curious_ about the things I was learning (in retrospect, I blame my then-undiagnosed ADHD).
+
+Finally, career services was critical to my job search. I graduated early (I joke that I dropped out) to take an internship that I had gotten through my network. That internship didn't pan out into the full-time opportunity I thought it would be, so I _went back to career services_. With a lot of valuable [lessons I learned in career services](/getting-your-first-software-engineering-job), I had a full-time offer 3-4 months later.
+
+---
+
+I hope this was helpful to you! If you're considering getting into software engineering and you have more questions, feel free to reach out to me on [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (please include a note, I might not accept otherwise).

--- a/apps/website-sv/src/content/writing/react-key-prop.md
+++ b/apps/website-sv/src/content/writing/react-key-prop.md
@@ -1,0 +1,220 @@
+---
+title: 'Cheat sheet: using keys in React'
+description: 'A couple recommendations (and warnings) about using the "key" prop'
+date: 2020-08-24
+tags:
+  - react
+  - javascript
+---
+
+I recently did a little refresher on how React keys work under the hood. Here's my cheat sheet on using React keys "dos and don'ts".
+
+## Use keys when rendering lists
+
+React makes sure you know about this rule with keys—if you render a list of items without keys React throws a console error in development.
+
+For example, consider the following JSX.
+
+```jsx
+const items = ['A', 'B', 'C'];
+
+const MyList = () => {
+	return (
+		<ul>
+			{items.map((letter) => (
+				<li>{letter}</li>
+			))}
+		</ul>
+	);
+};
+```
+
+If you render this component in a React app you'll see the following error.
+
+```
+Warning: Each child in a list should have a unique "key" prop.
+```
+
+This error be removed by attaching a `key` prop to each `li` inside of the `map`:
+
+```jsx
+const items = ['A', 'B', 'C'];
+
+const MyList = () => {
+	return (
+		<ul>
+			{items.map((letter) => (
+				<li key={letter}>{letter}</li>
+			))}
+		</ul>
+	);
+};
+```
+
+React uses these keys to optimize rendering of the list items. When items are added, deleted, or swapped inside of the list, React uses that `key` to determine which items changed.
+
+If the `key` is the same value, but in a different array _position_, then React can just reorder the rendered list items instead of recalculating them. But if the `key` is a different value, React knows it has to rerender the list item.
+
+## Put the key _in the array itself_.
+
+The `key` prop should be applied directly within the array. It doesn't matter whether it's a React component or a JSX element (HTML elements, like `li` or `div`).
+
+The rule of thumb recommended in the React docs is to _use `key` whenever you're inside the `map` method_.
+
+## Use a unique value as a key.
+
+We need to use a _unique_ value for each key. This is important—duplicate keys in our array React will throw another console error!
+
+```jsx
+const items = [
+  { id: '123', value: 'A' },
+  { id: '456', value: 'B' }
+  { id: '789', value: 'A' }
+]
+
+const MyList = () => {
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.value}>{item.value}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+In the above example, we'll have two items that use `"A"` as their key, since we're using `item.value`. We'll get the following console error:
+
+```
+Warning: Encountered two children with the same key, `A`. Keys should be unique
+so that components maintain their identity across updates. Non-unique keys may
+cause children to be duplicated and/or omitted — the behavior is unsupported
+and could change in a future version.
+```
+
+Duplicate keys can be a source of some really strange bugs. For example, changing a components' state affects _a different component_ or items that don't properly update when you expect them to. 😱
+
+We can fix this error if we use `id` on each item, which **is** unique. Most times that we're rendering data we'll have something like an `id` that we can use for a `key`.
+
+```jsx
+const items = [
+  { id: '123', value: 'A' },
+  { id: '456', value: 'B' }
+  { id: '789', value: 'A' }
+]
+
+const MyList = () => {
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>{item.value}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Use the array index as a last resort
+
+One might be tempted to use the array index of the list item as the `key` prop. After all, that's unique, right?
+
+In fact, [the React docs explicitly say](https://reactjs.org/docs/lists-and-keys.html#keys) that using the array index as a `key` is not recommended. Under the hood, React already uses the `index` as the key if there isn't an explicit `key` prop.
+
+When you use an `index` as the key, React treats it the same as using _no key_. It only removes the console error.
+
+When using the `index` in the `key`, React isn't able to optimize rendering of added, deleted, and reordered items.
+
+_Note: using an `index` as the `key` is ok **if there is no other unique value** that can be used as a `key`. If you won't be adding, removing, or reordering your arrays, you can likely use `index` and be fine._
+
+If we add an item to the front of our list, every existing item has its' index incremented by `1`. If we're using `index` for the `key`, every key changes and React has to rerender the entire list.
+
+Lastly, using the `index` inside of string `key` doesn't change this behavior—the `key` still changes when we reorder the list. It doesn't matter whether they're on their own or part of a larger string.
+
+```jsx
+const list = ['A', 'B', 'C'];
+
+const ListWithIndexInString = () => {
+	return (
+		<ul>
+			{list.map((letter, i) => (
+				// This is exactly the same as `key={i}`
+				<li key={`letter-${i}`}>{letter}</li>
+			))}
+		</ul>
+	);
+};
+```
+
+## Keys only need to be unique across siblings
+
+Even though component keys need to be unique within an array, they only need to be unique [**from their sibling components**](https://reactjs.org/docs/lists-and-keys.html#keys-must-only-be-unique-among-siblings). This is important to remember because it simplifies the `key` values that we choose.
+
+This aspect of keys is also one of the most misunderstood (or ignored) that I've seen in the wild.
+
+The following is correct `key` usage, despite the same keys appearing in multiple places:
+
+```jsx
+const items = ['A', 'B'];
+
+const MyList = () => {
+	return (
+		<ul>
+			{items.map((outerLetter) => (
+				<div key={outerLetter}>
+					{items.map((innerLetter) => (
+						<li key={innerLetter}>
+							{outerLetter}: {innerLetter}
+						</li>
+					))}
+				</div>
+			))}
+		</ul>
+	);
+};
+```
+
+There's no need for use to make keys like `` `outerItem__${outerLetter}` `` and `` `innerItem_${innerLetter}` `` that are unique across the entire component. We just need to make sure that _sibling_ components have unique keys.
+
+Sometimes tracing the `key` values can be a little tricky, especially with the nested `map`s. I find it helpful to think about the tree that React builds while rendering these components:
+
+```js
+const tree = {
+	root: {
+		type: 'ul',
+		children: [
+			{
+				type: 'div',
+				key: 'A',
+				children: [
+					{ type: 'li', key: 'A', children: ['A: A'] },
+					{ type: 'li', key: 'B', children: ['A: B'] }
+				]
+			},
+			{
+				type: 'div',
+				key: 'B',
+				children: [
+					{ type: 'li', key: 'A', children: ['B: A'] },
+					{ type: 'li', key: 'B', children: ['B: B'] }
+				]
+			}
+		]
+	}
+};
+```
+
+Using the following tree, we can see that key uniqueness only matters at **each indentation level**. Two components are at different levels of the tree can have the same `key` values without there being any problem.
+
+---
+
+## tl;dr
+
+Use a `key` prop to allow React to optimize adding, deleting and reordering list items. `key` values should be unique, but they only need to be unique across sibling components.
+
+---
+
+## Resources
+
+- [Lists and keys (React docs)](https://reactjs.org/docs/lists-and-keys.html): the official docs on keys are fantastic—they thoroughly explain how to properly (and improperly) use keys.
+- [Reconciliation (React docs)](https://reactjs.org/docs/reconciliation.html#recursing-on-children): this is a deep-dive into how React turns JSX into actual rendered HTML, as well as why keys are necessary.
+- [Index as a key is an anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318): this article describes a couple potential bugs that can come from using `index` as the key prop.

--- a/apps/website-sv/src/content/writing/refactoring-legacy-code-with-jest-snapshots.md
+++ b/apps/website-sv/src/content/writing/refactoring-legacy-code-with-jest-snapshots.md
@@ -1,0 +1,14 @@
+---
+title: 'Refactoring legacy code with Jest snapshots'
+description: In this article I share a method for introducing a little safety when working with legacy code without having to pause and set up a full testing suite.
+draft: false
+date: 2019-03-26
+publisher: LogRocket
+link: https://blog.logrocket.com/refactoring-legacy-code-with-jest-snapshots-e290ceccccc3/
+tags:
+  - testing
+  - jest
+  - javascript
+---
+
+In this article I look at some of the downsides to snapshot testing and why it generally isn't the best approach for your long-term testing strategy. I then share an appropriate use-case for snapshot testing to help when refactoring legacy code.

--- a/apps/website-sv/src/content/writing/regex-test-side-effects.md
+++ b/apps/website-sv/src/content/writing/regex-test-side-effects.md
@@ -1,0 +1,110 @@
+---
+title: Using "regex.test" with the "global" flag
+date: 2020-07-23
+draft: false
+tags:
+  - javascript
+  - regex
+---
+
+I recently came up on this JavaScript quirk while debugging some form input validators that were failing intermittently. When I finally found the source of the bug, I was surprised at this behavior from the seemingly innocent [Regex.prototype.test](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) function.
+
+If you're not familiar with `Regex.prototype.test` it seems somewhat straightforward: take a regular expression (regex) in JavaScript and plug a string into its `test` method. If the string matches the regex, the method returns `true`. Otherwise it returns `false`.
+
+There's one caveat.
+
+_If the regex being tested contains the global flag, `regex.test(str)` relies on more than just the input `str`._
+
+## So what's going on?
+
+To put it in functional programming terms—`regex.test` is not a pure function if you use the `g` flag on your regex.
+
+Here's an example of this behavior in action.
+
+```js
+// note that we're using the `g` flag
+const regex = /test/g;
+
+// returns true
+regex.test('test123');
+
+// returns false 😭
+regex.test('test123');
+
+// returns true
+regex.test('test123');
+```
+
+Why does this happen? Is it that the JavaScript gods are fickle and have chosen to punish us mortal programmers for not choosing a language like Java? Is it baked into the language so that we can have one more piece of trivia to stump candidates in interviews? (Don't do this btw. Interviews are about seeing whether someone is a good fit for your company, not about proving you're smarter than them).
+
+The reason that this happens is because JavaScript regexes contain a [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) property that tells `regex.test` and [regex.exec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) where to start searching the input string.
+
+Both methods set the `lastIndex` value on the regex to the _last matched index_. But they only do this if the regex has the `g` flag. If the end of the string is reached without finding any matches, `lastIndex` is set to `0`.
+
+Here's the same example from before, but also showing the value of `lastIndex`:
+
+```js
+// note that we're using the `g` flag on the
+const regex = /test/g;
+console.log(regex.lastIndex); // 0
+
+// returns true
+regex.test('test123');
+console.log(regex.lastIndex); // 4
+
+// returns false 😭
+regex.test('test123');
+console.log(regex.lastIndex); // 0
+
+// returns true
+regex.test('test123');
+console.log(regex.lastIndex); // 4
+```
+
+## How do we work around this quirk?
+
+There's a couple ways that we can write our application to be resilient against bugs stemming from this JavaScript gotcha.
+
+Certainly the simplest way to get around this issue is to remember that `regex.test` behaves like this if the `g` flag exists and not use it on regexes that have the `g` flag.
+
+Especially if the primary usage of the regex is testing strings, we probably don't need the `g` flag since we can either just test for the existence of a match (no `g` flag) or that the string starts/ends how we expect (using `^`, `$`, [groups, and ranges](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)).
+
+We could have avoided the entire problem if we just removed the `g` flag from the regex itself.
+
+```js
+const regex = /test/;
+
+// returns true
+regex.test('test123');
+
+// returns true 🎉
+regex.test('test123');
+```
+
+Personally, I think this is the ideal solution—we're using the method as intended, and our regexes reflect the way that we intend them to be used.
+
+Sometimes this isn't perfectly possible though. Perhaps you're using the regex in another context where it needs to have the `g` flag. Perhaps you're not entirely sure _which_ regex will be passed in to your code and you just want to make it more predictable.
+
+If the regex absolutely _has_ to have the `g` flag, we can provide some much-needed purity to our code by using the slightly less ergonomic [String.prototype.match](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) method and casting it into a `Boolean`.
+
+```js
+// note that we're using the `g` flag again
+const regex = /test/g;
+const str = 'test123';
+
+// returns true
+Boolean(str.match(regex));
+
+// returns true 🎉
+Boolean(str.match(regex));
+```
+
+It's not as ergonomic, but it still provides the same `boolean` result. Since `string.match` returns an array of matches and `null` if there's no matches in the string, we can turn this into a `boolean` just by wrapping it in the `Boolean` function to convert it.
+
+## tl;dr
+
+_JavaScript's `regex.test(str)` mutates a `lastIndex` property. The next time you call `regex.test` it starts testing `str` from `lastIndex` instead of the beginning. This means that multiple calls to `regex.test` might return different results, even if they were called with the same arguments._
+
+---
+
+Feel free to hit me up on my [Twitter](https://twitter.com/benjamminj) or [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) with any thoughts or if you enjoyed this article. If you found a typo or have some feedback for improvement also feel free to [submit a pull request](https://github.com/benjamminj/portfolio). Thanks for reading! 🎉

--- a/apps/website-sv/src/content/writing/small-prs.md
+++ b/apps/website-sv/src/content/writing/small-prs.md
@@ -1,0 +1,55 @@
+---
+title: How to create small PRs
+subtitle: Make your team's life easier by keeping diffs small.
+date: 2021-09-15
+tags:
+  - teamwork
+  - pull-requests
+  - software-engineering
+---
+
+When you work in teams, you'll spend lots of time reviewing code. And at some point you'll get assigned a PR that's 1,000+ lines long.
+
+Guess what? That PR is gonna take a long time to review unless you just slap a "LGTM" comment and YOLO-approve it.
+
+In contrast, small PRs result in higher-quality reviews and faster turnaround time.
+
+But how do you go from sending your teammates behemoth PRs to creating small, independently mergable diffs? Here's a few techniques to take those mega PRs and make them easier to review.
+
+## Split large features into multiple PRs
+
+The common reason behind large PRs is putting _**everything**_ for a new feature in a single PR. Sometimes it's 2-3 days' work, other times it could be _**weeks**_ of work. 😱
+
+Instead of working on the entire feature and _then_ opening a massive PR, try splitting the feature into multiple chunks that can each be merged separately.
+
+For example, do the backend in one PR and the frontend in another, or add the UI with mock data and do a second PR to wire up the API. Or do refactoring in a PR before you add the new behavior.
+
+You might even be able work in parallel with someone else on your team depending on how you split the tasks!
+
+Is splitting a complex feature up into multiple PRs a lot of extra work? 100%. But it makes life _way_ easier on your reviewers, which is well worth it.
+
+## Feature. Flags.
+
+If you're doing continuous deployment, splitting a big feature into small PRs poses a new problem—how do you safely merge work that's half-baked?
+
+Enter [feature flagging](https://martinfowler.com/articles/feature-toggles.html).
+
+Feature flagging allows you to keep merging code and deploying it to production without actually showing it to users. Then, once you're confident the feature is ready you can flip the flag on and send it to real users!
+
+This pairs nicely with small PRs since you don't need to wait for a feature to be "done" before you merge it in.
+
+## Watch the size of your diff, and look for stopping places
+
+When I'm working on a big feature, I'll do my work normally, but I'll also periodically check to see the size of my diff. If that diff starts getting large (for me that's ~400 lines) I'll start looking for a good way to open a PR for my in-progress work.
+
+It's better to start looking for a stopping place early than it is to push up your work only to realize your PR is 1,200 lines long.
+
+---
+
+## Conclusion
+
+Learn how to create small PRs and you'll notice they get reviewed a lot faster. While it's not an easy skill to develop, it's certainly a valuable one, especially when you're working in a team. After all, the main point of PRs is _**communication**_, not gatekeeping!
+
+## Extra resources
+
+- [Small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html) by Google engineering. _(CL is short for **change list**, which to my understanding is the same as a pull request)_.

--- a/apps/website-sv/src/content/writing/testing-animations-in-react-native.md
+++ b/apps/website-sv/src/content/writing/testing-animations-in-react-native.md
@@ -1,0 +1,164 @@
+---
+title: Testing Animated Components in React Native
+description: As a result of my issues with testing React Native components with animations I learned quite a bit about how React Native and Jest environment are set up.
+date: 2019-02-17
+tags:
+  - react-native
+  - testing
+---
+
+I came up upon this issue a couple weeks back and it's been bouncing around my head as food for a blog post since. I've always thought that the "write the blog post you wish you had" concept is great. The hard part is that after you're done solving difficult problems, you barely have any energy left to write the post!
+
+Anyways, I've been working a fair amount in React Native the past few months. It's certainly been a learning experience since this is my first time delving into native development. In addition, something that I'm pretty passionate about is setting up a solid testing suite for whatever project I'm working on (that is, if it doesn't already have tests). I'm a firm believer that a well-written testing suite can [save hours of time and thousands of dollars](https://www.computer.org/csdl/mags/so/2007/03/s3024.pdf).
+
+As a result I've been learning quite a bit about testing React Native apps with Jest. And recently I came up on an especially tricky test. I had this component that contained an animation—via React Native's `Animated` module. Internally, the component triggered some state changes along with some animations. While I can't share the actual component in this post, I do want to document how to manage these types of tricky tests.
+
+In my unit test I wasn't trying to do anything _too_ fancy. Render the component, fire some "onPress" events, and then run some assertions on how the component had changes. But the first time I ran my tests, I ended up with the following error:
+
+```
+ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
+```
+
+When the test runs the state update, this triggers the animation inside the component. However, by the time that the animation runs, the test has already run all of its assertions and completed. So by the time the [animation's callback](https://facebook.github.io/react-native/docs/animated#working-with-animations) triggers a `setState`, the component has already unmounted!
+
+## Why can't we just mock `Animated`?
+
+As a first solution, I thought I might be able to get away with mocking out the entire `Animated` module from React Native. However, after some consideration I decided _against_ this for a few reasons.
+
+First off, the `Animated` module is decently complex, and coming up with a solid mock is not a small feat. It contains multiple animation components, functions to control timing and easing, and some of the APIs allow [method chaining](https://javascriptissexy.com/beautiful-javascript-easily-create-chainable-cascading-methods-for-expressiveness/). When mocking it's important to have something that's API-compatible with the real module—or at least the parts that you're using. I found that my component was using a sizable portion of the `Animated` API, so it would take quite a bit of effort to mock it out. While not impossible, it's worth acknowledging that a mock wouldn't be simple.
+
+However, that's not the only reason. Whenever you mock out a module you decrease the similarity that your code _under test_ has to your code _in the real world_. There's a lot of opinions about this, for example this article on [why mocking is a code smell](https://medium.com/javascript-scene/mocking-is-a-code-smell-944a70c90a6a). My preference is to lean more on the side of integration testing and less on mocking when it comes to testing software (especially for front-end apps). So, I wanted to actually use the `Animated` module to make sure that my tests were more accurate.
+
+What I wanted is to mock _something_ in the testing environment that allowed me to use the _real_ `Animated` module _without throwing the Jest error_.
+
+## Why we can't only use `jest.useFakeTimers`
+
+Jest ships with a tool exactly for testing these scenarios—[`jest.useFakeTimers`](https://jestjs.io/docs/en/timer-mocks.html). Using `jest.useFakeTimers` allows us to mock out _time itself_ and how the test runner progresses through time.
+
+So I figured I'd try it out. All you've got to do is call the function at the top of your test suite:
+
+```jsx
+beforeEach(() => {
+	jest.useFakeTimers();
+});
+```
+
+And then to advance the fake time, you can do something like this:
+
+```jsx
+// inside a test
+// move forward 500ms
+jest.advanceTimersByTime(500);
+```
+
+Turns out this creates an _entirely new error_ specific to only the testing environment. The error goes something like this:
+
+```
+Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out...
+```
+
+### Why do we get `Ran 100000 timers, and there are still more!`?
+
+This error was even more cryptic to me and the first one! And when it came to finding out the answers, I had to spend a long time digging through StackOverflow posts and GitHub issues. Fortunately, I eventually stumbled on [this StackOverflow answer](https://stackoverflow.com/a/51067606).
+
+Turns out, React creates a polyfilled version of `requestAnimationFrame` in order to run its animations. And that Reach Native's implementation of `global.requestAnimationFrame` uses `setTimeout(fn, 0)` under the hood. While this is all good in normal execution context (it just runs on the next tick of the runtime), when we're using `useFakeTimers` the `setTimeout(fn, 0)` spins off a bunch of new timers (1 per timeout) very quickly. This causes Jest to bail out because the stack gets too large and it thinks that you accidentally created an infinite recursion. Not good!
+
+## Time travelling (and StackOverflow) to save the day
+
+In addition to finding out why I was getting this cryptic error, I also found a really nice solution on StackOverflow that I adapted to actually be able to test animations reliably—without extensive mocking of `Animated`.
+
+This is only slightly adapted—personally, I don't like 100% copy-pasting code from StackOverflow. I find that when I take the time to rewrite the code in my own "words" I understand what's actually happening a bit better—even if it looks almost identical to the original code.
+
+So let's see how we could implement a solution.
+
+First, we need to mock out the `requestAnimationFrame` to not use `setTimeout(fn, 0)` under the hood. If we assume that we'll be using `jest.useFakeTimers` to actually move _forward_ through time, `setTimeout` itself isn't the issue. The issue is `useFakeTimers` along with `setTimeout(fn, 0)`. So what we can do is change the timeout that `requestAnimationFrame` uses under the hood.
+
+```jsx
+// in a test setup file, or your test itself
+const FRAME_TIME = 10;
+
+global.requestAnimationFrame = (cb) => {
+	setTimeout(cb, FRAME_TIME);
+};
+```
+
+What this does is simulate a new frame every 10 milliseconds. You could put any number here, but the reason why I like 10 for the timeout amount is because it allows us to avoid mathematical gymnastics inside of our unit tests. For example, if we travel forward by 300ms, it's easy to mentally calculate that we'll advance by 30 frames.
+
+Now that we've polyfilled `requestAnimationFrame`, the next order of business is to set up a `timeTravel` function. This makes sure that when we're travelling forward through time we do all of the things necessary so that React Native's animations run correctly in the test environment.
+
+```jsx
+// timeTravel.js
+import MockDate from 'mockdate';
+
+const FRAME_TIME = 10;
+
+const advanceOneFrame = () => {
+	const now = Date.now();
+	MockDate.set(new Date(now + FRAME_TIME));
+	jest.advanceTimersByTime(FRAME_TIME);
+};
+
+const timeTravel = (msToAdvance = FRAME_TIME) => {
+	const numberOfFramesToRun = msToAdvance / FRAME_TIME;
+	let framesElapsed = 0;
+
+	// Step through each of the frames until we've ran them all
+	while (framesElapsed < numberOfFramesToRun) {
+		advanceOneFrame();
+		framesElapsed++;
+	}
+};
+
+export default timeTravel;
+```
+
+It's worth noting that we _do_ need this `timeTravel` function in addition to the `requestAnimationFrame` polyfill. The main reason has to do with the way that React Native's `Animated` module calculates elapsed time (and an animation's progress). Under the hood, it uses the current date (`Date.now`) to calculate how much time elapsed since the animation began.
+
+As a result, we have to make sure that each frame we advance in `timeTravel` updates `Date.now`. In the `advanceOneFrame` function we take the current `Date.now` value and make sure that it advances forward by one "frame" (10ms). I'm using a library called [`MockDate`](https://github.com/boblauer/MockDate) which makes testing with dates an absolute breeze. In addition, we advance the Jest timers using `jest.advanceTimersByTime`. This makes sure that our Animation is calculated correctly _and_ our `setTimeout`s get called without creating infinite recursion.
+
+Then, in the `timeTravel` function we take a single argument—the amount of time to "move forward"—and use it to calculate how many frames this would be. After that it's a matter of wrapping our `advanceOneFrame` function inside a `while` loop. This makes sure we keep stepping forward one frame at a time until we've hit our `msToAdvance` number.
+
+Lastly, we need to do a little bit of setup in order to use this function. I find it helpful to create a `setupTimeTravel` function that can be dropped into Jest's `beforeEach` whenever I make test utilities like this. Even though our `setupTimeTravel` function isn't too complex, it's useful since it keeps everything related to this utility contained to one place.
+
+```jsx
+// timeTravel.js
+export const setupTimeTravel = () => {
+	MockDate.set(0);
+	jest.useFakeTimers();
+};
+```
+
+The first line of our `setupTimeTravel` function isn't 100% necessary, but it certainly helps. Because `Animated` relies on `Date.now` to calculate elapsed time, setting it to `0` makes it easier to reason about our animation logic later on. However, you _could_ get by without it, so leave it out if you want to!
+
+However, we do need to use `jest.useFakeTimers` in our `setupTimeTravel` function—if you leave this out the `timeTravel` function won't work!
+
+### Using our `timeTravel` function in a test
+
+Now that we've got our brand new `timeTravel` function, let's see what it could look like in a test!
+
+```jsx
+import { timeTravel, setupTimeTravel } from './path-to/timeTravel';
+
+beforeEach(setupTimeTravel);
+
+describe('<ComponentWithAnimation />', () => {
+	test('works with animations', () => {
+		// render the component
+		// trigger some animation
+
+		// this actually moves the timers forward
+		// and simulates the frames over 500ms
+		timeTravel(500);
+
+		// run assertions on the animated state here
+	});
+});
+```
+
+---
+
+## Conclusion
+
+I thought that this issue with testing React Native Animations was especially interesting. As a result of my issues with testing this component I learned quite a bit about how React Native calculates animation duration as well as how the Jest environment was set up. When I was googling all over for that "Ran 100000 timers, and there are still more!" error, there wasn't too much to find, and if I had this blog post then it certainly would have been helpful! I hope that this was helpful to any of you reading along!
+
+If you enjoyed reading this article, you're welcome to check out and follow me on [Twitter](https://twitter.com/benjamminj). I promise I'll share any time I post something new. And if you want to edit this post at all please feel free to open a [PR on GitHub](https://github.com/benjamminj/portfolio). Thanks for reading! 🎉

--- a/apps/website-sv/src/content/writing/things-to-keep-an-eye-on-in-2018.md
+++ b/apps/website-sv/src/content/writing/things-to-keep-an-eye-on-in-2018.md
@@ -1,0 +1,44 @@
+---
+title: 5 Front-End Technologies I'm Keeping My Eye on in 2018
+description: Here's some things I'm placing bets on & diving into in 2018.
+date: 2018-01-06
+image:
+  url: 'ace-card.jpg'
+  alt: Ace of Spades against a black background
+---
+
+My wife is from Las Vegas. At New Years Eve just a week ago, Las Vegas swarmed with over 300,000 guests. Some of those guests left a lot richer than when they were when they arrived in Vegas, no doubt having won a sheer stroke of luck (or maybe skill, they claim). Others, not so much.
+
+Learning new technologies can sometimes feel akin to gambling &mdash; especially if you feel that your time has value to it. You can sink hours of ever-so-precious personal time into learning some new framework, language, or programming paradigm only to watch it fall into obscurity 3 months later. On the flipside, there's tremendous gains to be won if you choose wisely and become an early adopter of "the next big thing".
+
+2017 was a big year for me &mdash; at the beginning of the year I was just starting to dive into React & the modern JavaScript ecosystem. Up until then, I'd mostly been working with more legacy codebases & jQuery as the frontend library of choice. And now, less than 1 year later, I've been working as a professional React developer for roughly 6 months at a top-notch [startup](https://www.autogravity.com) based in Irvine.
+
+Throughout the last year I did some gambling on which technologies I'd learn on my free time &mdash; I won a few, and had quite a few that didn't pay off as well as I'd hoped.
+
+Anyways, here's some things I'm placing bets on & watching/diving into in 2018.
+
+## React
+
+This is a safe bet...it's also hard to ignore that React is currently the 200-ton juggernaut in the front-end space, and it doesn't look like anything is going to usurp its position soon. I'm using React every day at work, and it's not too much extra effort to stay up to date on modern component architectures, API changes, best practices, etc. happening in the React space. In addition, the team behind React is doing an amazing job at staying at the cutting edge of modern web development.
+
+## WebAssembly
+
+In mid-November of 2017 [Mozilla announced](https://blog.mozilla.org/blog/2017/11/13/webassembly-in-browsers/) that support for WebAssembly ships by default in all major modern browsers (sorry, IE11 users, but you're not a "major browser" anymore). With growing support of this new web standard I think web development will start to see new paradigms and best practices pop up as many traditionally server-side & embedded systems programming languages suddenly become available on the web.
+
+## Web Components & Custom Elements
+
+Web Components/Custom Elements allow for a ton of awesome things in front-end development. An obvious plus from using them is simple framework-agnostic sharing of styles & UI components. This means that developers using these components (whether it's you using your own, open source users, or other developers within your organization) don't have to bother about which framework/library/rendering engine you used to write components, they can simply use them the same way they use a `<button>` or an `input` tag. Furthermore, it will be interesting to see what front-end architectures arise as companies use custom elements more and more &mdash; some people are already advocating for a "[microservices for the front-end](https://micro-frontends.org/)" approach towards building UIs.
+
+## CSS Variables
+
+CSS Custom Properties (CSS Variables) are currently supported in the four major modern browsers. They essentially allow you to store values in a variable that is evaluated by the CSS parser _at runtime_. This is far more flexible & leads to more interesting usages than preprocessor variables that get evaluated in a compile step (especially when paired with a framework like React). I think that much like we saw **tons** of best practices & tutorials emerging for CSS Grid in the latter half of 2017, we're gonna see tons of developers discovering & sharing best practices around CSS Custom properties in 2018.
+
+## GraphQL
+
+GraphQL got reeeallly big in 2017. Right now, the list of companies using this technology is a who's who of the tech scene: Facebook, GitHub, Pinterest, Intuit, etc. Basically, GraphQL operates as a "query language for your API", allowing the user of the API to retrieve only the data they've explicitly requested. However, I'm seeing a trend of beginning to use GraphQL for querying things other than API endpoints &mdash; [Gatsby's](https://www.gatsbyjs.org/docs/) currently using it to query all data & generate static sites, and I recently saw [another project](https://dev-blog.apollodata.com/the-future-of-state-management-dd410864cae2) working to use GraphQL as a frontend state management tool. It's no doubt that as it becomes more familiar and we see more success stories from larger companies that it will only increase in adoption.
+
+## Conclusion
+
+Let's set one thing straight here, though. **It's 100% possible that I'm wrong about any of these predictions.** After all, choosing technologies is gambling, and when you gamble sometimes you lose. However, these are all technologies that I've seen gaining traction in 2017 and I think they all show promise. It's also important to remember that this list isn't inclusive of _everything that's interesting to me_, but rather kinda a "top picks" specifically for the front-end web development space at this given point in time.
+
+What about you? What things are you interested in for 2018? Feel free to [tweet at me](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) if you've got thoughts to share. 😎

--- a/apps/website-sv/src/content/writing/thoughts-on-elm.md
+++ b/apps/website-sv/src/content/writing/thoughts-on-elm.md
@@ -1,0 +1,164 @@
+---
+title: Some Thoughts on Elm
+date: 2018-01-27
+description: Elm is a functional compile-to-JavaScript language used for building robust, bug-resistant UIs.
+image:
+  url: 'elm-logo.png'
+  alt: Elm Logo
+tags:
+  - functional-programming
+---
+
+I've been playing around with Elm off & on since mid-2017. In short, Elm and I have a complex relationship. I **love** Elm as a language &mdash; the syntax just kinda gets out of your way / lets you focus on what you're actually writing, and the compiler is a strict-yet-loving teacher. In addition, it's a huge relief to feel confident that _code that compiles will not throw runtime exceptions_.
+
+However, at the same time the rest of the front-end ecosystem is sprinting onward (on many fronts!) & I'm using React at work, so it's difficult to devote any significant portion of my free time to playing around with Elm.
+
+For those of you that aren't too familiar with Elm, it's a functional _compile-to-JavaScript_ language primarily used for building robust, bug-resistant UIs. Even though it's a completely different language than JavaScript, it's intended use case sets it in direct competition with other JavaScript frameworks, like React, Angular, & Vue. However, the differences are **huge** (for better or for worse) &mdash; Elm really is a completely different language!
+
+Here's a couple of the key differences that I've experienced in the past few months of playing with Elm.
+
+## Pros
+
+### 1. Strong Typing
+
+Elm is a _strongly-typed_ language, as opposed to JavaScript's _weak typing_. This means that all of the functions you declare have a _type signature_.
+
+For example, if I wrote a function named `add` that takes two numbers & returns the added result, it would look like this.
+
+<u>**JavaScript:**</u>
+
+```javascript
+const add = (a, b) => a + b;
+```
+
+<u>**Elm:**</u>
+
+```haskell
+add: Number -> Number -> Number
+add a b =
+  a + b
+```
+
+The key to strong typing comes in when I want to _ actually use_ the function. What happens if I forget to pass a number & instead pass strings as my parameters?
+
+<u>**JavaScript:**</u>
+
+```javascript
+const sum = add('a', 'b'); // returns the string "ab" 🤔
+```
+
+<u>**Elm:**</u>
+
+```haskell
+sum = add "a" "b" -- throws a compiler error that's helpful! 🎉
+```
+
+The definition of the function in Elm includes a _type signature_ &mdash; indicating that the `add` function takes 2 numbers as parameters & returns a number as a result. Since the Elm compiler is usually smart enough to _infer_ your type signatures for you, you don't actually have to type this signature to get all the strongly-typed goodies. However, I found that as I played more with Elm, I found myself thinking about the type signatures of the functions that I was writing.
+
+While JavaScript has had a few attempts to bring types to it (notably [Flow](https://flow.org/) & [TypeScript](https://www.typescriptlang.org/)), they both fall way short of Elm's type syntax & static type checking capabilities. In Elm, type declarations feel more like a first class citizen, encouraging developers to think about types more often.
+
+### 2. Enforced Error Handling
+
+In Elm, the compiler will get reaaaaaaallly angry if you don't handle potential points of failure in your application code.
+
+For example, let's say you make a network request for some JSON. You're gonna operate on this JSON blob to render a blog post (like the one you're reading. Thanks 😜) You expect the JSON to look like this.
+
+```json
+{
+	"title": "Some cool stuff about Elm",
+	"body": "It's fun!",
+	"author": "Benjamin Johnson",
+	"dateCreated": "2018-01-25"
+}
+```
+
+Easy peasy, right? You just get the JSON, and use the appropriate keys to render your blog post.
+
+**Not so fast.**
+
+What happens if the network went down in between when the user loaded your web page & when they made this request?
+What happens if the JSON sends back an array of authors instead of a String?
+What happens if `dateCreated` is `null`?
+
+All of these are possiblities, especially if you're relying on a third-party API to deliver your content or you're working with other developers. And as much as you might want to say "That shouldn't happen. The backend engineers will let me know when they change the payload", the fact is that sometimes this type of stuff happens, even in the best of organizations.
+
+In JavaScript, you _could_ (not saying you always do, & definitely not saying you should!) write the code to assume that the JSON response loads perfectly every time. You might not find out that your app failed until you get either an error saying `` Cannot read property `body` of `undefined`. `` and now you have to crawl through a debugger. Or you accidentally render the word `null` to your screen. Not the best UX by a long shot.
+
+Elm forces you to write error-handling code for any operations that could _potentially fail_. Like network requests, or GeoLocation in the browser, or time-based operations (converting a string into a timestamp, for example). The main reason it's even capable of doing this is the static type system. When the compiler sees one of these "potentially failable" operations without error-handling code, it just refuses to compile until you write something to handle your errors.
+
+Like I said, it's possible to write JavaScript that handles those potential errors, but it's really helpful to have the compiler on your side when you forget to write an error handler. I've seen a lot of bugs that happened because a developer forgot to handle an edge case or write code that was defensive to all points of failure.
+
+### 3. Purely Functional
+
+While a purely functional language is awesome, purity without some form of state management doesn't work well for UIs (we need to be able to respond to user input & state changes 😜). Elm keeps the language pure by managing state mutations inside of the Elm runtime. This method of managing state updates, more commonly known as "[The Elm Architecture](https://guide.elm-lang.org/architecture/)" is also quite common outside of the Elm community (React + Redux is a prime example).
+
+Programming with this paradigm makes your UI a pure function of application state, meaning that it becomes incredibly simple to reason about portions of your app. _Everything in Elm is just a function_, and this tends to produce fairly readable, easy-to-reason-about code (a win in every way!).
+
+## Cons
+
+### 1. It's Hard To Beat The JavaScript Ecosystem
+
+Say what you want about the "JavaScript fatigue" & having a new framework pop up each week: there's a _ton_ of competition in the front-end JS world, and this results in the best solutions rising to the top (usually).
+
+Also, if you're playing with a new JS framework, it's usually not too difficult to get it to integrate with other portions of your favorite front-end stack (CSS/SCSS/LESS/CSS-in-JS, utility libs, etc.).
+
+Intermingling with JavaScript code makes it much more difficult for Elm to type-check & deliver on its promise of "no runtime exceptions", so there's a process of communicating with JavaScript packages via "ports". However, communicating with a JS port can tend to be rather tedious, and I found myself writing a lot of my own logic for things that I likely would have used a utility for had I been working in JS.
+
+I'm a big fan of staying minimal & only using 3rd-party dependencies when you need them, but a beautiful part of the JS ecosystem is that you can consume these packages on NPM when you need to move fast or when you want to isolate a specific concept you're learning (i.e. you only want to learn Vue as a framework so you use Vue Material or Bootstrap so you don't spend all of your precious time styling your components).
+
+### 2. HTML Templating is Little Strange
+
+Everything that I heard from the Elm community said that over time you get used to the HTML syntax, but it never really caught on for me. Here's a quick example of an Elm "template" (or "view" function).
+
+```haskell
+view model =
+  div []
+    [ button [ onClick Decrement ] [ text " - " ]
+    , div [] [ text (toString model) ]
+    , button [ onClick Increment ] [ text " + " ]
+    ]
+```
+
+In the above example, each HTML element is a function that takes two arguments & is named after its' corresponding HTML tag. The first parameter contains a `List` (array) of all the HTML attributes to be applied to the tag. The second parameter contains an array of all the children of the element. The theory behind doing HTML templating this way is that _everything in Elm is simply a function_, but in practice, it just feels a tiny bit clunky to me.
+
+Compare this to something like JSX, which feel much closer to raw HTML.
+
+```jsx
+const view = (model) => (
+	<div>
+		<button onClick={Decrement}> - </button>
+		<div>{model}</div>
+		<button onClick={Increment}> + </button>
+	</div>
+);
+```
+
+Or something like Vue's template syntax, which just builds on top of HTML
+
+```html
+<div>
+	<button v-on:click="Decrement">-</button>
+	<div>{{model}}</div>
+	<button v-on:click="Increment">+</button>
+</div>
+```
+
+In my opinion, both the React & Vue template syntaxes are quite a bit easier to read quickly, although they might not be quite as flexible & composable as Elm's HTML functions.
+
+### 3. Lack of Support From a Major Company
+
+On one hand, I hesitate to even make this a point against Elm as a language. The language should stand or fall on the way that it operates alone (in a perfect world...).
+
+However, what I've found when talking to colleagues is that the primary concern about Elm is due to the fact that it's not supported by a major company. I would venture that the reason I haven't seen too many companies adopt it is that without the big \$\$\$ from a major company, the evolution & support of the language could potentially end abruptly.
+
+The front-end landscape shifts pretty quickly, and keeping a language up-to-date is a full-time job (props to the people currently supporting Elm). Couple that with the fact the compile target (JavaScript) isn't staying still: in fact, JavaScript is moving at breakneck speed, gaining new features & browser APIs every year. Hopefully we will see Elm stick around & continue to keep up-to-date, as it's a really pleasant language to write in.
+
+## Conclusion
+
+I still think that Elm is 100% worth learning &mdash; if you have the time. It's valuable for the way that it forces you to think about programming. What happens if the JSON you recieve from a server doesn't have the key you expect? What if the user's browser fails to give you geolocation data? (Both have been sources of particularly tricky bugs in JS I've worked on in the past year or so).
+
+Elm forces you to handle all your errors, dot all your "t's", cross all your "i's". Even if you don't start using it in the workplace, the benefits from stretching your mind & trying new paradigms are huge.
+
+However, I also know & feel the sentiment of those with reservations towards Elm. It is a different, unfamiliar language to many working in the front-end ecosystem, and the tradeoffs that it makes in favor of type security & runtime safety do add a bit of complexity if you're trying to move quickly or operate with other parts of the front-end ecosystem.
+
+Like what you read? Disagree? Feel free to [tweet at me](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/). Thanks for reading!

--- a/apps/website-sv/src/content/writing/three-ways-to-break-focus-state.md
+++ b/apps/website-sv/src/content/writing/three-ways-to-break-focus-state.md
@@ -1,0 +1,14 @@
+---
+title: '3 ways everyone breaks their website’s focus state'
+description: Common ways to break your app for anyone using a keyboard.
+
+date: 2019-01-15
+publisher: LogRocket
+link: https://blog.logrocket.com/3-ways-everyone-breaks-their-websites-focus-state-b0d29bdeda11/
+tags:
+  - accessibility
+  - css
+  - html
+---
+
+In this article I look into a few common mistakes I've seen (and done 😱) when dealing with focus state.

--- a/apps/website-sv/src/content/writing/trampolines-for-recursion.md
+++ b/apps/website-sv/src/content/writing/trampolines-for-recursion.md
@@ -1,0 +1,13 @@
+---
+title: 'Using trampolines to manage large recursive loops in JavaScript'
+description: In this article I talk about a nifty trick for getting around call stack overflows when using recursion in JavaScript.
+
+date: 2018-05-14
+publisher: LogRocket
+link: https://blog.logrocket.com/using-trampolines-to-manage-large-recursive-loops-in-javascript-d8c9db095ae3/
+tags:
+  - javascript
+  - functional-programming
+---
+
+In this article I talk about a nifty trick for getting around call stack overflows when using recursion in JavaScript.

--- a/apps/website-sv/src/content/writing/typesafe-errors-in-typescript.md
+++ b/apps/website-sv/src/content/writing/typesafe-errors-in-typescript.md
@@ -1,0 +1,154 @@
+---
+title: Leaning into TypeScript for type-safe error handling
+description: You get more out of the type system if you think of the compiler as your friend instead of  a gatekeeper.
+date: 2020-04-12
+draft: false
+image:
+  url: 'pawel-czerwinski-unsplash.jpg'
+  alt: 'Abstract rock pattern with vibrant colors'
+tags:
+  - typescript
+  - exception-handling
+---
+
+Over the past year I've been working on a large TypeScript project, and I'm happy to say I'm now officially on "team TypeScript".
+
+Previously I've felt a little cautious about jumping on the TypeScript hype train for two main reasons:
+
+- **"It's too verbose."** Compared to JavaScript, TypeScript is certainly much more verbose. Other statically typed languages, like Reason and Elm don't require you to write nearly as many type annotations either.
+- **"The type system isn't strong enough."** Using the `any` type lets you break out of type-checking entirely, so the type system is only strong as long as you're diligent enough to add the type annotations correctly. Compare this to Reason and Elm—the other statically-typed languages I've worked in—and you'll see that they both have much stronger type systems.
+
+I've written about both of these before—here's [an article I wrote a while back](https://blog.logrocket.com/what-makes-reasonml-so-great-c2c2fc215ccb/) on why Reason is so cool. I still think Reason is cool, but I'm no longer hesitant about TypeScript.
+
+After working with TypeScript (TS) for a while, I think it has a type system that's _strong enough_ to provide confidence. The verbosity I felt when using TS was more due to unfamiliarity.
+
+I'm a firm believer that when using a static type system you get more out of it by leaning _into_ the type system rather than fighting against the type system. It's best if you think of the compiler as your friend instead of your enemy.
+
+Which brings me to the focus of this article—how we can work _with_ TypeScript to handle errors.
+
+## Why throwing errors isn't type-safe
+
+A very common style of handling errors in JavaScript (and TypeScript) is to `throw` an error. `throw` is built-in to JavaScript—by `throw`ing an `Error` it propagates up the stack until it reaches a `catch` block.
+
+```js
+function throwsError() {
+	throw new Error('😱');
+}
+
+try {
+	throwError();
+} catch (error) {
+	// we have access to the error here.
+}
+```
+
+Using `throw` to handle errors isn't bad—many server frameworks like NestJS and Express use this method since you can use a single `catch` block at the top of your app. This means you're able to handle all errors in your app in a single location—regardless of their point of origin.
+
+In React you can catch errors coming from your components using [`componentDidCatch`](https://reactjs.org/docs/error-boundaries.html) and creating an `ErrorBoundary` component (I'm not too sure about other front-end frameworks since I mostly work in React).
+
+However, just because `throw` is common doesn't mean it's _type-safe_. Anytime you `throw` an error, you need to have a `catch` block to catch it or it could potentially bubble up and crash your app! TypeScript isn't able to infer that your code using `throw` is nested inside a `catch` block so whenever you use `catch` you're relying on developer diligence instead of the type system to make sure your app won't crash on flaky data.
+
+## Using a `Result` type to leverage the type system
+
+So, how can we manage failure and uncertainty in our app in a way that allows the type system to catch potentially unsafe code for us?
+
+I have a custom type that I use to wrap unsafe code, here's what it looks like:
+
+```ts
+type ResultSuccess<T> = { type: 'success'; value: T };
+
+type ResultError = { type: 'error'; error: Error };
+
+type Result<T> = ResultSuccess | ResultError;
+```
+
+The `Result` type is an example of a TypeScript _union type_—it represents something that could be a `ResultSuccess` _or_ a `ResultError`. `ResultSuccess` and `ResultError` both have a `type` property, but other than that the objects are completely different.
+
+Here's what it would look like to have a function that returns a `Result` type.
+
+```ts
+let myFunction = (value: string): Result<number> => {
+	if (value === '0') {
+		return { type: 'error', error: new Error('The value cannot be 0') };
+	}
+
+	return { type: 'success', value };
+};
+```
+
+This example is fairly small—the function doesn't do much more than checking whether the `value` is `0` or not. However, the benefits of a `Result` type become clearer when we slap it on an API request:
+
+```ts
+import axios from 'axios';
+
+let myRequest = async (id: string): Result<User> => {
+	try {
+		let result = await axios.get(`/my-api/users/${id}`);
+		return { type: 'success', value: result.data };
+	} catch (error) {
+		return { type: 'error', error };
+	}
+};
+```
+
+One note about using `axios` for data fetching is that it will automatically `throw` an error if the API returns anything with a 400-level or 500-level response. While this means you don't _have to_ check for successful responses, this opens us up to the danger that an uncaught exception crashes the entire app.
+
+However, if we wrap the `axios` call in a try/catch block, how do we type that? And what if we actually _do_ want to `throw` an error from our failed requests?
+
+When we have our "risky" code return a `Result`, TypeScript is smart enough to force us to check the `Result` type for a successful response _before_ we try to use the value.
+
+```ts
+let fetchDataAndNotify = async () => {
+	let data = await myRequest('@benjamminj');
+
+	if (data.type === 'success') {
+		return `The user's name is ${data.value.name}`;
+	}
+
+	return `There was an error fetching this user.`;
+};
+```
+
+I'll admit, having these types of checks around the codebase isn't the "prettiest" thing in the world. But it's certainly better than having the app randomly crash when data is missing or API requests fail. Fault-tolerance and safety are more valuable than avoiding a couple `if` blocks!
+
+Using `Result` allows us to take a potential runtime error and turn it into a compile-type error:
+
+```ts
+let fetchDataAndNotify = async () => {
+	let data = await myRequest('@benjamminj');
+
+	// This line will be a TS error, since `data.value` doesn't exist on
+	// `ResultError` and we don't know for sure that `data` is a `ResultSuccess`
+	return `The user's name is ${data.value.name}`;
+};
+```
+
+As an added bonus, if you _do_ want to throw an error, the `ResultError` type contains an actual `Error`. This gives you full control over how and when errors get thrown from your app.
+
+```ts
+let renderEssentialData = async () => {
+	let data = await myRequest('@benjamminj');
+
+	if (data.type === 'error') {
+		// If this data is essential to the app, it's better to fail fast than to
+		// show potentially malformed or invalid states.
+		throw data.error;
+	}
+
+	// Do stuff with the data here, TS knows that it's a ResultSuccess type by now.
+};
+```
+
+And that's it! I've been using this approach for most of the API calls coming into the front-end. I'm really happy with how it's turned out on the apps where I've implemented it! Instead of having random crashes, I'm forced time and time again by the compiler to either design error states for missing data or API failures.
+
+## Influences and Prior Art
+
+This pattern isn't something I came up with out of the blue, so I want to highlight a couple key influences I had in discovering this pattern.
+
+One of the key influences for this `Result` interface came from the [`Option` type in Reason](https://reasonml.github.io/docs/en/null-undefined-option). The `Option` type is the way that Reason allows you to deal with nullable data without compromising its type safety. It's fairly similar to the `Maybe` monad in Elm and Haskell if you're a fan of those languages.
+
+Secondly, I've gotten a lot of great TypeScript patterns from [TypeScript Deep Dive](https://basarat.gitbooks.io/typescript/) by [Basarat Ali Syed](https://github.com/basarat). Specifically, his section on [exception handling](https://basarat.gitbook.io/typescript/type-system/exceptions#you-dont-have-to-throw-an-error) was influential in me using this `Result` pattern.
+
+Lastly, I wanted to reiterate that that the best solutions with TypeScript typically come from leaning _into_ the type system rather than fighting against it. This `Result` type came out of desiring to find a way to force my team (myself included) check for error states rather than optimistically trusting that certain functions (primarily API requests) will always return successfully.
+
+If you enjoyed this, please let me know on my [Twitter](https://twitter.com/benjamminj) or [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) with a share! If you found any errors or bugs in this article let me know or submit a pull request to update this article.

--- a/apps/website-sv/src/content/writing/typescript-async-function.md
+++ b/apps/website-sv/src/content/writing/typescript-async-function.md
@@ -1,0 +1,119 @@
+---
+title: Type definitions for async functions in TypeScript
+description: Understanding how JavaScript async functions work under the hood helps us know exactly how to type them in TypeScript.
+date: 2020-04-22
+draft: false
+image:
+  url: 'photo-boards-shapes.jpg'
+  alt: 'Abstract wall decor in blue, yellow and brown'
+tags:
+  - typescript
+  - promises
+  - async
+---
+
+One of the things that tripped me up when I first started using TypeScript was how to write type definitions for async functions.
+
+Async/await syntax were added to ECMAScript in 2017 (or ES8), and it's incredibly useful for dealing with asynchronous code. If you're unfamiliar with async/await, this is what the syntax looks like:
+
+```js
+async function fetchData(id) {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+}
+```
+
+Or, if you prefer using arrow functions, the above function's equivalent would look like this:
+
+```js
+const fetchData = async (id) => {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+};
+```
+
+Changing a regular function into an async function happens just by using the `async` keyword in front of the function declaration. By doing this, we're able to use the `await` keyword to simply have our function pause execution until whatever we're `await`ing is resolved.
+
+Before we get to writing TypeScript definitions, it's important that we have a thorough understanding of how JavaScript [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) work. The reason for this is that async/await is just a pretty syntax for promises! So when we get around to type definitions, typing an async function is exactly the same as typing a function that returns a promise.
+
+Our sample function _without async/await_ would look like this:
+
+```js
+function fetchData(id) {
+	// resolves with an array of users
+	return fetch(`https://example.com/users/${id}`).then((result) => result.json());
+}
+```
+
+This function and the async/await version are _the same_ in terms of how they behave and what type of values they return. The difference is purely in the syntax.
+
+_💬 **A quick note:** since async/await is just a pretty syntax for promises, you might find that in some cases using the regular promise syntax feels cleaner. This is ok—it's not wrong to use async/await and promises interchangeably based on the situation. I personally think our example lends itself more to promises since there's only a single `.then` being chained._
+
+## Now to the type definitions!
+
+Armed with the knowledge that an async function is a fancy syntax for a function that returns a promise, we can move on to writing the type definitions.
+
+TypeScript has a built in `Promise` type we can use to describe promises—it's a [generic type](https://www.typescriptlang.org/docs/handbook/generics.html) so we'll pass in the _type_ that the promise resolves with.
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+// This type describes a promise resolving with an array of user objects.
+type UsersPromise = Promise<User[]>;
+```
+
+Once we've identified how to wrap our `User` interface in the `Promise` type all that's left to do is attach it to our function and add the other type annotations:
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+async function fetchData(id: string): Promise<User[]> {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+}
+```
+
+We give `id` a type of `string` so that TypeScript knows how to infer its type, and then just attach the `Promise<User[]>` to `fetchData` as the return value. This tells TypeScript that the function operates asynchronously and anyone using it will need to either `await` it or use `fetchData(id).then(users => {})` to actually make use of the fetched `users` data.
+
+If you prefer to use [type aliases](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-aliases) for your functions, you can use the same TypeScript syntax along with declaring the function slightly differently to type the async function with a type alias:
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+// Type alias
+type FetchData = (id: string) => Promise<User[]>;
+
+const fetchData: FetchData = async (id) => {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+};
+```
+
+This can be especially useful to decrease verbosity if the async function you're typing has multiple or complex parameters.
+
+---
+
+Thanks for reading—I hope that this was helpful to you in figuring out how to still use async/await syntax while giving TypeScript enough info to properly infer the shapes of the data your async functions are returning.
+
+As always, feel free to hit me up on my [Twitter](https://twitter.com/benjamminj) or [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) with any thoughts. If you found a typo in this article or have some feedback for improvement please feel free to [sumbit a pull request](https://github.com/benjamminj/portfolio).

--- a/apps/website-sv/src/content/writing/typescript-generics.md
+++ b/apps/website-sv/src/content/writing/typescript-generics.md
@@ -1,0 +1,273 @@
+---
+title: TypeScript generics
+date: 2020-09-11
+lastUpdated: 2020-09-12
+tags:
+  - typescript
+---
+
+## tl;dr 🙃
+
+TypeScript generics create reusable type definitions by letting you make some parts configurable. They're like **function parameters for your types.**
+
+## Overview: basic generic types 🧱
+
+Generic types can be difficult to wrap your mind around, especially when you're new to TypeScript. They're certainly tougher than type annotations (`const a: number = 1`) or interfaces.
+
+Part of this is because generic types are **abstract types**.
+
+Their syntax might also be somewhat unfamiliar—especially if you're coming from JavaScript. You might be wondering what these `<>` brackets are doing all over the code. 😱
+
+To dive into generic types, let's start with a couple of type definitions. Imagine we have interfaces for a `User` and a `Post` in a blogging app.
+
+```ts
+interface User {
+	id: string;
+	name: string;
+	email: string;
+	phoneNumber: string;
+}
+
+interface Post {
+	id: string;
+	userId: string;
+	title: string;
+	body: string;
+}
+```
+
+Now, let's think about data fetching in our fictional blogging application. We probably have some API endpoints that return paginated lists of data. Something like `/api/users` and `/api/:userId/posts`.
+
+The interfaces for the paginated API response could look something like this.
+
+```ts
+interface UsersListResponse {
+	// Array of User objects
+	data: User[];
+	page: number;
+	totalPages: number;
+	totalCount: number;
+	perPage: number;
+}
+
+interface PostsListResponse {
+	// Array of Post objects
+	data: Post[];
+	page: number;
+	totalPages: number;
+	totalCount: number;
+	perPage: number;
+}
+```
+
+You'll notice that the `UsersListResponse` and the `PostsListResponse` are nearly identical. The only thing that isn't copy-pasta is the `data` property—in one it's a `User` array, in the other a `Post` array.
+
+With two interfaces it's not difficult to keep them synced. But as our applications grow we'll get more interfaces and maintaining the _interfaces_ gets progressively more difficult.
+
+TypeScript generics let us create a single source of truth for _types_.
+
+They're function paramaters for type definitions.
+
+With generics, we can rewrite `UsersListResponse` and `PostsListResponse` to look like this.
+
+```ts
+interface PaginatedResponse<T> {
+	data: T[];
+	page: number;
+	totalPages: number;
+	totalCount: number;
+	perPage: number;
+}
+
+type UsersListResponse = PaginatedResponse<User>;
+type PostsListResponse = PaginatedResponse<Post>;
+```
+
+The _generic_ portion is the `<T>` in `PaginatedResponse<T>`—this sets up a type "parameter" named `T`. We can then use `T` inside our interface to configure the _type_ of certain properties.
+
+In this case we want to configure `data` as a `T[]` since it's an array of whatever type `T` is.
+
+_You can name `T` anything you like. Using `T`, `U`, and `K` as generic parameter names is a convention you'll see a lot in TypeScript code—especially for simple interfaces. Think of `T` like using `i` in a `for` loop._
+
+Then, to create our two interfaces from before we can drop the `User` and `Post` types into the `<>` brackets on `PaginatedResponse`. So we end up with the exact same interface as before by doing `PaginatedResponse<User>`.
+
+Leveraging these generic types allows us to easily respond to changes within our codebase in a type safe. For example, what if we added a new type of `Label` to the system? This is all we'd need on the TypeScript front.
+
+```ts
+interface Label {
+	id: string;
+	name: string;
+	color: string;
+}
+
+type LabelsListData = PaginatedResponse<Label>;
+```
+
+## A deeper dive: advanced generic types
+
+I hope this small example has shown some of the ways that generic types can help in making your TypeScript code less verbose and more elegant!
+
+The examples above cover some basic usage of generic types. In this section we'll dive a little deeper and look at some extra "tricks" to make our generics even more useful. 💪
+
+### Constrained generic types
+
+Sometimes we want to provide a generic type, but we don't want it to allow any type as a parameter. Instead, we want to limit the parameter to a few approved types.
+
+```ts
+interface IndividualResponse<T extends object> {
+	data: T;
+}
+
+// ✅ This compiles correctly.
+type UserByIdResponse = IndividualResponse<User>;
+
+// 🚨 This gives the following compiler error:
+// "Type 'number' does not satisfy the constraint 'object'."
+type NumberResponse = IndividualResponse<number>;
+```
+
+The type constraint is that `extends object` bit. I like to think of it as similar to typing a function argument.
+
+```ts
+const add = (a: number, b: number) => a + b;
+```
+
+In this `add` function TypeScript doesn't care about what values we pass into `a` and `b`. But it does throw compiler errors if those values aren't `number` types. In a similar way our `IndividualResponse` type will allow any type as a parameter as long as it is an `object`. Since `number` isn't an `object` type, we get a compiler error.
+
+### Default generic types
+
+In the same way that we can provide a type constraint to an interface, we can also provide a default type when we're creating generics.
+
+```ts
+interface IndividualResponse<T = object> {
+	data: object;
+}
+
+const response: IndividualResponse = someData;
+const numberResponse: IndividualResponse<number> = someOtherData;
+
+// This will have a a type of "object"
+response.data;
+
+// This will have a a type of "number"
+numberResponse.data;
+```
+
+It's usually a good idea to add some default type if you're planning on having your interfaces get reused a lot (unless you can infer the type from a function parameter—we'll get to that next).
+
+Lots of libraries use this approach in their type definitions because it gives you some default type safety out of the box without forcing you to use the `<>` syntax every time you use their API. And then if you want better type checking you can use the `<>` and pass your types in. Best of both worlds! 🔥
+
+### Inferring generics from function parameters 🤯
+
+One of the most powerful ways to use TypeScript generics is to infer their type from function parameters.
+
+Consider this simplified version of the `Array.prototype.filter` function.
+
+```ts
+const filter = <T = unknown>(array: T[], validate: (value: T, index: number) => boolean): T[] => {
+	const newArray = [];
+	for (let i = 0; i < array.length; i++) {
+		const value = array[i];
+		const isValid = validate(value, i);
+
+		if (isValid) {
+			newArray.push(value);
+		}
+	}
+
+	return newArray;
+};
+
+const above3 = filter([1, 2, 3, 4, 5], (number) => number > 3); // Returns [4, 5]
+
+above3; // Type is a "number[]"
+```
+
+This is way more confusing on the syntax front. Let's break down what's going on in `filter`.
+
+First, we have `<T = unknown>` in front of the parentheses. This has the same purpose as `interface Name<T>`—this is just the syntax for adding a generic to a function.
+
+```ts
+const filter = <T = unknown>(array, validate) => {
+	// function body
+};
+```
+
+Next, let's look at the `array` parameter to `filter`.
+
+```ts
+const filter = <T = unknown>(array: T[], validate) => {
+	// function body
+};
+```
+
+This says that the argument we pass as `array` should be our dynamic `T` type.
+
+This alone is actually enough for TypeScript to **infer** that when we call `filter([1, 2, 3, 4], value => value > 3)` that `array` will be a `number[]` and not something else!
+
+But we can go a few steps further.
+
+Let's take a look at the `validate` argument.
+
+```ts
+const filter = <T = unknown>(array: T[], validate: (value: T, index: number) => boolean) => {
+	// function body
+};
+```
+
+We can also use `T` when typing our `validate` function to say that _whatever the type of the array is, the "value" should be the same type_.
+
+This means that when we do `filter([1, 2, 3, 4], value => value > 3)` the compiler actually knows that `value => value > 3` should be a **number**. If we tried to do `value => value.toUpperCase()` we'd get a compiler error, since `toUpperCase` only exists on `string` types.
+
+Finally, we add `T[]` as the return type of the function.
+
+```ts
+const filter = <T = unknown>(array: T[], validate: (value: T, index: number) => boolean): T[] => {
+	// function body
+};
+```
+
+This seems like crazy rocket science. Maybe even over-the-top, wouldn't it just be easier to use `any` types?
+
+But it all comes together when we actually put our `filter` function into action.
+
+```ts
+const above3 = filter([1, 2, 3, 4, 5], (value) => value > 3);
+```
+
+You'll notice that this **doesn't have any types added**. It's plain JavaScript.
+
+But if we look at the type of `above3` in an IDE we'll see it's a `number[]`. In VSCode you can hover over the variable and you'll see its type. Looking at `value` also shows it's a `number` too. 🔥
+
+We gave enough hints to the compiler that all it needed was `[1, 2, 3, 4, 5]` to figure out all of the type definitions.
+
+---
+
+Defining generic types this way can be difficult to get right. Chances are you'll struggle with the compiler your first few times.
+
+But the reward is type safety without syntax clutter bleeding into other parts of your app. You drastically cut down on verbosity without sacrificing on type safety.
+
+Using generic types this way lets you hide the verbose TypeScript typings inside the function itself. That way you don't force others to manually provide types whenever they're using `filter`.
+
+## A warning about generics 🚧
+
+As you can see, TypeScript generics can range from simple to ridiculously complex. It's easy for them to get out of hand if you're not careful.
+
+Don't go overboard when creating generic types—a little duplication is preferable to overengineering.
+
+TypeScript code is just a tool to help you write JavaScript—it's all going to get compiled down into JavaScript when you ship it. The type definitions are for _developers only_.
+
+Good developer experience does matter, but it doesn't come at the expense of shipping a good user experience. The last thing you want to do is spend a bunch of time on TypeScript typings and ship nothing.
+
+Personally, I cap my attempt at around 30 minutes. That's usually enough for me to get it working. But if I still can't get the generic type right I add `unknown` or `any` and continue with my work. Sometimes I'll circle back around to it, sometimes I won't. 🤷‍♀️
+
+If getting generic types is difficult at first, keep trying! Like all programming concepts, it gets easier with practice.
+
+---
+
+## Resources
+
+For some further reading on TypeScript generics, check out these resources. 🤓
+
+- [Basarat's TypeScript Deep Dive](https://basarat.gitbook.io/typescript/type-system/generics)
+- [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/generics.html#using-type-parameters-in-generic-constraints)

--- a/apps/website-sv/src/content/writing/use-debounced-value.md
+++ b/apps/website-sv/src/content/writing/use-debounced-value.md
@@ -1,0 +1,132 @@
+---
+title: useDebouncedValue
+subtitle: Create a debounced copy of an input value.
+date: 2020-12-22
+tags:
+  - react
+  - typescript
+  - recipes
+---
+
+```tsx
+import { useState, useEffect } from 'react';
+
+export const useDebouncedValue = <T extends any>(input: T, delay = 0) => {
+	const [value, setValue] = useState(input);
+
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			setValue(input);
+		}, delay);
+
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, [input, delay]);
+
+	return value;
+};
+```
+
+## Context
+
+When building UIs it's nice to respond to user input _immediately_. In React it's generally ok to call `setState` multiple times in quick succession since [React batches state updates](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous).
+
+However, you _don't_ want to rapidly update a state value if you've got a `useEffect` wired up to it. This could have disastrous results (like DDoSing your API or terrible render performance). 😱
+
+This hook creates a carbon copy of the original state value. The only difference is that the `useDebouncedValue` doesn't update _until its dependency stops updating_.
+
+This makes it much safer to use as a dependency for `useEffect` if your state is rapidly changing.
+
+While debouncing the `fetch` function (or any function called from within `useEffect`) achieves a similar effect, I think debouncing the _value_ results in cleaner logic. Since you trigger an effect whenever dependencies change, you debounce the effect by changing dependencies less. Overall, it feels more inline with React's data flow and the way that `useEffect` works.
+
+## Usage
+
+```tsx
+import { useEffect, useState } from 'react';
+import { useDebouncedValue } from './useDebouncedValue';
+
+export const Component = () => {
+	const [posts, setPosts] = useState([]);
+	const [search, setValue] = useState('');
+	const debouncedValue = useDebouncedValue(search);
+
+	useEffect(() => {
+		fetch(`https://jsonplaceholder.typicode.com/posts?search=${debouncedValue}`)
+			.then((res) => res.json())
+			.then((posts) => setPosts(posts))
+			.catch(() => setPosts([]));
+	}, [debouncedValue]);
+
+	return (
+		<div>
+			<label>
+				Search
+				<input name="search" value={search} onChange={(ev) => setValue(ev.target.value)} />
+			</label>
+
+			<div>{posts.length} posts found</div>
+		</div>
+	);
+};
+```
+
+## Tests
+
+```tsx
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useDebouncedValue } from './useDebouncedValue';
+
+jest.useFakeTimers();
+
+test('should return the first value immediately', () => {
+	let value = 1;
+	const { result } = renderHook(() => useDebouncedValue(value));
+	expect(result.current).toEqual(1);
+});
+
+test('should not update the value immediately after a change', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => useDebouncedValue(value));
+	expect(result.current).toEqual(1);
+
+	value = 2;
+	rerender();
+	expect(result.current).toEqual(1);
+});
+
+test('should update the value after the delay time', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => useDebouncedValue(value, 100));
+	expect(result.current).toEqual(1);
+
+	value = 2;
+	rerender();
+	jest.advanceTimersByTime(99);
+	expect(result.current).toEqual(1);
+
+	act(() => {
+		jest.advanceTimersByTime(1);
+	});
+	expect(result.current).toEqual(2);
+});
+
+test('should default to a delay of 0', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => useDebouncedValue(value));
+	expect(result.current).toEqual(1);
+
+	value = 2;
+	rerender();
+	act(() => {
+		// Just run the next tick of the call stack.
+		jest.advanceTimersByTime(0);
+	});
+	expect(result.current).toEqual(2);
+});
+```
+
+## Influences and prior art
+
+- **[usehooks.com](https://usehooks.com/useDebounce/)**: I mostly lifted my `useDebouncedValue` function from here. It's not a 100% copy-pasta though: I've renamed a few things, added my own comments, added some tests and ported it to TypeScript.
+- **[`useDeferredValue`](https://reactjs.org/docs/concurrent-mode-reference.html#usedeferredvalue)**: This is built-in to React's concurrent mode and will only update the given value after a timeout period. This hook is a big reason why I think that a `useDebouncedValue` hook feels inline with React's data flow. I might not even need `useDebouncedValue` once concurrent mode is stable! 😅

--- a/apps/website-sv/src/content/writing/use-previous.md
+++ b/apps/website-sv/src/content/writing/use-previous.md
@@ -1,0 +1,81 @@
+---
+title: usePrevious
+subtitle: Store a reference to the value from the last render.
+date: 2021-02-02T00:00:00.000Z
+tags:
+  - react
+  - hooks
+  - typescript
+  - recipes
+---
+
+```tsx
+import { useEffect, useRef } from 'react';
+
+/**
+ * Stores a reference to the previously rendered value.
+ *
+ * This can be used to execute dependency checks to compare whether a single
+ * dependency has changed.
+ *
+ * During the first render, `undefined` will be returned. Following renders will
+ * return a value.
+ */
+export const usePrevious = <T extends unknown>(value: T) => {
+	const ref = useRef<T | undefined>();
+
+	useEffect(() => {
+		ref.current = value;
+	}, [value]);
+
+	return ref.current;
+};
+```
+
+## Context
+
+This hook can be really useful when you want to bail out of a `useEffect` early. Or if you have a `useEffect` with a few dependencies but you want to wait until a certain one has changed.
+
+Technically, this hooks is kinda a "hack", I feel like it doesn't line up perfectly with React's data flow and programming model for hooks. I _think_ in most cases there's a "better" way—something like flipping a flag based on the dependency that needs to update. But I've found myself reaching for `usePrevious` in most of medium-to-large applications I've built the last few years.
+
+## How it works
+
+`usePrevious` starts of by setting up a `useRef` in the first render. This will initially be `undefined` (since in the first render there isn't a previous value).
+
+Secondly, we set up a `useEffect` to sync that `ref` after each render cycle. [`useEffect` runs _after_ each render](https://reactjs.org/docs/hooks-reference.html#useeffect) is committed to the screen, so in the _next_ render cycle, you'll have the _previous_ render cycle's value stored in `ref.current`
+
+## Usage
+
+```tsx
+const Component = ({ query, filter }) => {
+	const previousQuery = usePrevious(query);
+
+	useEffect(() => {
+		// If the query didn't change, bail out early
+		if (query !== previousQuery) return;
+
+		// Otherwise, continue fetching as usual.
+		fetchData(query, filter);
+	}, [query, previousQuery, filter]);
+
+	// render data
+};
+```
+
+## Tests
+
+```tsx
+import { renderHook } from '@testing-library/react-hooks';
+import { usePrevious } from './usePrevious';
+
+test('should return the value of the previous render', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => usePrevious(value));
+	expect(result.current).toEqual(undefined);
+	value = 2;
+	rerender();
+	expect(result.current).toEqual(1);
+	rerender();
+	expect(result.current).toEqual(2);
+});
+```

--- a/apps/website-sv/src/content/writing/using-rem-based-media-queries.md
+++ b/apps/website-sv/src/content/writing/using-rem-based-media-queries.md
@@ -1,0 +1,26 @@
+---
+title: Using rem-based media queries
+date: 2020-09-29
+tags:
+  - css
+---
+
+One of my favorite CSS "tricks" is the `rem`-based media query:
+
+```css
+@media screen and (min-width: 48rem) {
+	/*  Styles for tablets and above */
+}
+```
+
+Instead of using pixels for the width of the screen, you can define the width of the screen using `rem` units. One key benefit to this is **accessibility**.
+
+I often bump my font size up larger than the default. While I can see fine without it I find the larger font sizes relaxing on my eyes.
+
+Writing media queries like this allows you to scale layout with a user's font-sizing preferences. So if your user has a tablet screen (~768px) and a 150% font size, they would see the _mobile_ layout. This mobile layout is more helpful if your font is taking up a significant portion of your tablet-sized screen width.
+
+Lastly, a couple caveats to this approach. First, if you're actually changing the `font-size` on the `html` element, this might not be for you. Personally, I've never had to actually change the root `font-size` dynamically so this is rarely a concern for me.
+
+Second, `rem`-based media queries can take a while to get used to. You'll have to do some math if you need to figure out standard screen sizes. For example, `768px` divided by a root font-size of `16` results in `48rem`. That said, I think the benefits (accessibility) outweigh the cost (unfamiliarity).
+
+Thanks for reading! Let me know if you enjoyed this—you can reach out to me on [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (make sure to mention this post if you do connect!)

--- a/apps/website-sv/src/content/writing/what-makes-reasonml-so-great.md
+++ b/apps/website-sv/src/content/writing/what-makes-reasonml-so-great.md
@@ -1,0 +1,14 @@
+---
+title: 'What makes ReasonML so great?'
+description: As it turns out, quite a bit.
+
+date: 2018-09-10
+publisher: LogRocket
+link: https://blog.logrocket.com/what-makes-reasonml-so-great-c2c2fc215ccb/
+tags:
+  - reason
+  - functional-programming
+  - javascript
+---
+
+In this article I do an intro for an exciting programming language coming out of Facebook—Reason (also known as ReasonML).

--- a/apps/website-sv/src/content/writing/why-keeping-a-code-journal-will-make-you-a-better-developer.md
+++ b/apps/website-sv/src/content/writing/why-keeping-a-code-journal-will-make-you-a-better-developer.md
@@ -1,0 +1,48 @@
+---
+title: Why Keeping a Code Journal Will Help You Become a Better Developer
+description: Even if you’re not journaling frequently, reflection is one of the best ways to internalize the things that you learn.
+date: 2017-10-24
+image:
+  url: 'blog-img-journal.jpg'
+  alt: Journal and pen lying on a table
+---
+
+I’ll be honest — I straight-up stole this idea from [Ryan McDermott](https://medium.com/@ryansworks) after hearing him talk about keeping a code journal on [JS Jabber](https://devchat.tv/js-jabber/clean-code-javascript-with-ryan-mcdermott) and how it helped him write better code over time.
+
+Over the past 3–4 months I’ve been keeping a code journal of my own, and I can personally vouch for the benefits that come from taking a couple minutes to reflect on the code I read/wrote. Like any habit, it takes some time to form, especially when you’ve got real work to do — and I still miss days here and there. But I wanted to share a few of the benefits that I’ve noticed.
+
+## Keeping a Code Journal Forces You to Identify Code Smells.
+
+It’s truly rare to see a perfect codebase. If you’re working as a developer, chances are you’re spending most of your day reading code, and there’s bound to be something the code you read that’s less than perfect.
+
+Most of the time, if it’s something that super hard to understand, you either spend a couple extra minutes reading/understanding the code, or you go and ask the developer who wrote it.
+
+And then you go about solving the problem you were working on, and in a few weeks, you more or less forgot about the smelly code you read on that one occasion (after all, you’re on to something completely else by then).
+
+Furthermore, sometimes you know intuitively that something isn’t clean or easy to read, but you’re not exactly sure why.
+
+Both of these scenarios are a perfect case for keeping a code journal. By virtue of documenting what you read you’re forced to process why it was less than ideal (this has the side benefit of also exposing good alternatives), and you now have a written record that you can reference later. Win-Win.
+
+## Keeping a Code Journal Helps You Identify Clean Code.
+
+Your reflections shouldn’t be all negativity though. Chances are you work with a bunch of smart people (I know I do!) that are capable of writing beautiful, clean, readable code.
+
+Just like when noting code smells, sometimes you don’t intuitively know why the code you read is amazing, and chances are you’re not gonna remember it in a few weeks. Taking the time to process what was great about it will help you internalize the concepts.
+
+## Keeping a Code Journal Helps You With Personal Branding.
+
+One of the awesome side effects of writing down all of the clean/messy code you read is that you’re basically writing outlines for blog posts. If you’re anything like me, consistency and finding good material to write on are two of the hardest things.
+
+I’ll be honest, consistency with writing hasn’t been my strong suit, and I’m not gonna dive into that right now 😎. Keeping a code journal isn’t going to help you sit down and actually write articles. That’s more on the discipline side of things.
+
+However, keeping a code journal can help with inspiration. Think of it this way—if you write down one entry every other day (see, even not that consistently!), at the end of a week you’d have 3–4 ideas that you can look at for inspiration. And furthermore, you’ve already written a basic outline.
+
+## Conclusion
+
+Even if you’re not writing entries frequently, reflection is one of the best ways to internalize the things that you learn.
+
+Another thing to note. I’ve just been using a git repo with a bunch of markdown files. I find it really easy to go write something down and get back to work this way. But you don’t have to do it the way that I do — do whatever helps you best!
+
+What about you? Are there any specific things that you do to internalize the things that you encounter in your day-to-day learning?
+
+Thanks a bunch for reading. Let’s connect—feel free to connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) or tweet at me on [Twitter](https://twitter.com/benjamminj).

--- a/apps/website-sv/src/content/writing/why-ssr.md
+++ b/apps/website-sv/src/content/writing/why-ssr.md
@@ -1,0 +1,87 @@
+---
+title: Why SSR
+description: Server-rendering is more than just SEO and speed
+date: 2022-05-01
+tags:
+  - http
+  - software-engineering
+  - fundamentals
+---
+
+A common claim I've heard in recent years goes like this: "We don't need SEO because our app is B2B...so server-rendering (SSR) is overkill".
+
+However, there's many reasons to consider SSR as a good-enough default for most applications. Many apps are a blend of SSR and client-side fetching, and some apps _aren't_ a good fit for SSR.
+
+That said, many apps (most apps?) gain many benefits from leaning in to the server-rendered paradigm. Here's some additional reasons to adopt server-rendering beyond Lighthouse scores.
+
+## Server-rendering yields a simpler mental model
+
+If you _exclusively_ server-render (no client-side JS), every action follows the same workflow:
+
+1. Request enters your server through a HTTP request.
+2. Server processes the request and responds, usually HTML or a redirect.
+3. HTML document is sent to the user.
+
+Even though your app now runs in two environments (browser & server), you've simplified the data flow. Now you can focus on interaction and pizazz on the client-side and let the server do the heavy-lifting in regards to data.
+
+Going purely client-side usually introduces some additional workflows (examples are just from the React ecosystem). These aren't exclusive to client-side rendering, but they often accompany a more client-centric model.
+
+- Handling request waterfalls (querying per component, [React Suspense](https://reactjs.org/docs/react-api.html#reactsuspense)).
+- Caching API responses in-memory in JS ([Apollo](https://www.apollographql.com/docs/react), [React-Query](https://react-query.tanstack.com/)).
+- Updating application state without any data fetching ([Redux](https://redux.js.org/), [React State](https://reactjs.org/docs/state-and-lifecycle.html)).
+- Form libraries ([Formik](https://formik.org/docs/overview), [React-Hook-Form](https://react-hook-form.com/get-started), [Final Form](https://final-form.org/docs/final-form/getting-started))
+
+Most apps will be a blend of server-side and client-side patterns, but leaning entirely on client-side approaches may actually make things more complicated.
+
+## Speed is good for everyone.
+
+Fast apps are good on high-speed internet, too. Trust me, your enterprise users will appreciate that _your app_ isn't the one tanking their productivity with slow interactions.
+
+_(Also, with remote working, you can't assume that enterprise users have a high-speed connection anymore)_
+
+While SSR doesn't guarantee speed, it gives you fast defaults, and keeps the door open for future optimization.
+
+## Easier to optimize.
+
+You have no control over your user's device, browser, or internet bandwidth. In contrast, you 100% have the ability to make your server _fast_.
+
+Optimizing client-side apps often boils down to: A) fetch less often, B) optimize asset loading ([PRPL pattern](https://web.dev/apply-instant-loading-with-prpl/)), and C) [don't block the main thread](https://web.dev/mainthread-work-breakdown/). So once you've done all 3 of those you're completely at the mercy of your users' internet connections and device specs.
+
+When your server hsa long response times you have many more options to speed it up. You can optimize the infrastructure (scale vertically/horizontally, multi-region, edge, etc), add caching (CDNs, key-value stores, `Cache-Control` headers) or fix slow code paths (your server or upstream services).
+
+You're able to pick the optimization that makes the most sense at any given time, rather than hitting a wall.
+
+As an added benefit you get some of the client-side optimizations "for free" when you lean in to the server-centric model. Like fetching less via `Cache-Control` headers and keeping the main thread clear (since your server is doing the heavy lifting)
+
+## Server-rendered HTML is probably more accessible.
+
+SSR does not guarantee accessible HTML interfaces. That's up to you, the developer.
+
+However.
+
+HTML forms are _way_ easier to do when you have server-rendering. And if your HTML form works without JavaScript it has a much higher chance of being more accessible than 90% of the JS-only SPA forms out there.
+
+Turns out screen readers are great at reading HTML documents.
+
+## You can have your cake and eat it, too.
+
+SSR might not be able to deliver the 100% polished experience your users expect. You may (probably) want to use a JS framework to build components and structure your UI.
+
+Good news! Most JS frameworks support server-rendering with minimal configuration ([Next.js](https://nextjs.org/), [Remix](https://remix.run/), [SvelteKit](https://kit.svelte.dev/), [NuxtJS](https://nuxtjs.org/), etc).
+
+So you can get all the benefits of server-rendering, while also being able to write client-side JS to power those smooth, snazzy UXs your users have come to expect.
+
+Better yet, running client-side JS becomes an enhancement rather than _required_.
+
+---
+
+## Conclusion
+
+Server-rendering provides a variety of benefits over the fully client-rendered SPAs of today. With modern JS frameworks, you can easily adopt a server-rendered model without having to give up JS on the frontend. Finally, while SSR comes with _some_ complexity, it makes a number of things simpler, namely data fetching, form handling, and optimization.
+
+Have comments or concerns? Loved what you read? I deliberately don't have comments on my blog, so please hit me up on [Twitter](https://twitter.com/benjamminj)!
+
+## Further Reading
+
+- [This thread on Twitter](https://twitter.com/gortok/status/1519361629896552449)
+- [Remix docs](https://remix.run/docs/en/v1/pages/philosophy#serverclient-model)

--- a/apps/website-sv/src/content/writing/writing-a-memoize-function-from-scratch.md
+++ b/apps/website-sv/src/content/writing/writing-a-memoize-function-from-scratch.md
@@ -1,0 +1,356 @@
+---
+title: Writing a memoize function from scratch
+date: 2020-10-14
+tags:
+  - javascript
+  - from-scratch
+---
+
+## Intro
+
+In this tutorial we'll build our own `memoize` function from scratch.
+
+You might be (or might not be!) familiar with the term "memoize". To give a quick **tl;dr**, "memoize" is kinda a fancy word for "cache". Or to put it a different way, memoizing something is a way of adding caching to it.
+
+When we "memoize" something we cache the results of a function based on its arguments. This can be useful when you have a function that's very performance-intensive.
+
+Chances are you don't need to write your own memoization function for working in most codebases. If you're a `lodash` user, there's `_.memoize`. I've also used `memoize-one` in the past.
+
+But reimplementing things from scratch has other benefits—it's helpful for me when I want to solidify my knowledge of a concept. So here we go, here's `memoize` from scratch!
+
+## The "specs"
+
+Before we dive right in on coding our `memoize` function, let's take a moment and draw up some specifications.
+
+This is how we want `memoize` to look and behave:
+
+```js highlight-lines=3,4
+const sumBelow = memoize(someReallyExpensiveFunction);
+
+// returns `499999999067109000` after delay
+sumBelow(1e9);
+// returns `1999999998067114000` after delay
+sumBelow(2e9);
+
+// immediately returns `499999999067109000`
+sumBelow(1e9);
+```
+
+To further flesh out our "acceptance criteria", here's the things that `memoize` needs to do:
+
+- `memoize` needs to accept a function as an argument
+- `memoize` needs to return a _new_ function that can be used with the same arguments as the original function.
+- When the memoized function is called, it will run the original function.
+- However, **if the memoized function** is called again with the same arguments as a previous call, the result of the first call will be returned **immediately**.
+
+## Writing the function
+
+Alright, let's dive into the code for our `memoize` function.
+
+First, we'll need to set up `memoize` as a function that accepts a function as an argument. (If you're curious, these are often referred to as [higher-order functions](https://medium.com/javascript-scene/higher-order-functions-composing-software-5365cf2cbe99)).
+
+For now, we'll just have `memoize` call the original function with the arguments that were passed to it.
+
+```js
+const memoize = (fn) => {
+	return (...args) => {
+		const result = fn(...args);
+		return result;
+	};
+};
+```
+
+As we go through this tutorial we can use the following code to test whether our memoize function is working:
+
+```js
+// ...memoize function up above
+
+const sumBelow = (limit) => {
+	const sum = 0;
+
+	for (var i = 1; i < limit; i++) {
+		sum += i;
+	}
+
+	return sum;
+};
+
+const memoSumBelow = memoize(sumBelow);
+
+// Returns after a slight delay
+memoSumBelow(1e6);
+// Also returns after a small delay
+memoSumBelow(2e6);
+
+// Should return immediately!
+memoSumBelow(1e6);
+```
+
+If we run this with our current `memoize` function, we'll see that `memoSumBelow` returns the **correct** value each time, but it doesn't return immediately on the third call (the second one with `1e6`).
+
+Let's add a cache of calls to `memoize` so we can make that third call return instantly ⚡️
+
+We'll start by just setting up the cache. We'll use a JavaScript `Map` to store the results.
+
+```js
+const memoize = (fn) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const result = fn(...args);
+		return result;
+	};
+};
+```
+
+It's important that `const cache` is **outside** of the function that we `return`. (FYI, this is referred to as a [closure](https://whatthefuck.is/closure) if you're interested).
+
+Next, we'll want to create a cache key and put the result of `fn(...args)` in our newly created cache. For now we'll use the first argument as a cache key.
+
+```js
+const memoize = (fn) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = args[0];
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+Now there's one thing left to do—we check the cache to see whether the key exists. If it does, we can grab the item out of the cache instead of running `fn`. If it doesn't, we run `fn(...args)` and cache the result for next time.
+
+```js
+const memoize = (fn) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = args[0];
+
+		if (cache.has(cacheKey)) {
+			return cache.get(cacheKey);
+		}
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+## Bonus: writing unit tests 🤓
+
+Let's write some tests for our `memoize` function. I'll be using [Jest](https://jestjs.io/) in these examples.
+
+Before, let's take a step back and brainstorm about the things we _want to test_. We can use our `memoize` specifications that we wrote earlier along with `test.todo`.
+
+```js
+// memoize.test.js
+
+test.todo('should run the function if it has not been called with the same arguments');
+
+test.todo('should return a cached result if the function has been called with the same arguments');
+```
+
+In the first test, we'll run our memoized function with arguments that it has _not been called with_. We'll then verify that the underlying `fn` argument got called correctly.
+
+First, let's remove `test.todo` and replace it with an actual test. At the top of our test we'll create a new mock function using `jest.fn()`.
+
+In this case, we don't need something complicated or performance-intensive—we're just testing that the function gets called, so a simple `plus1` function will do. We'll pass it into `memoize`.
+
+```js
+// memoize.test.js
+
+test('should run the function if it has not been called with the same arguments', () => {
+	const plus1 = jest.fn();
+	const memoizedFn = memoize(plus1);
+});
+```
+
+> _If you're familiar with the [Arrange-Act-Assert pattern](https://wiki.c2.com/?ArrangeActAssert) for writing tests, this bit we just did is the "Arrange" portion of the test._
+
+Next, let's call `plus1` (btw, this is the "Act" portion of Arrange-Act-Assert).
+
+```js
+// memoize.test.js
+
+test('should run the function if it has not been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	const result = memoizedFn(1);
+});
+```
+
+Finally, we can add our assertion.
+
+```js
+// memoize.test.js
+
+test('should run the function if it has not been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	const result = memoizedFn(1);
+
+	expect(result).toEqual(2);
+	expect(plus1).toHaveBeenCalledTimes(1);
+	expect(plus1).toHaveBeenCalledWith(1);
+});
+```
+
+In this test we want to assert three things about our `memoize` function:
+
+1. That `memoizedFn` returned the correct value (`.toEqual(2)` in our case).
+2. That `memoizedFn` was only called once (`.toHaveBeenCalledTimes(1)`). This will matter more in the next test.
+3. That `memoizedFn` actually was called with an argument of `1` (`.toHaveBeenCalledWith(1)`).
+
+For the second test, the first portion of the test looks exactly the same:
+
+```js
+// memoize.test.js
+
+test('should return a cached result if the function has been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+});
+```
+
+However, we'll call `memoizedFn` slightly differently. We're going to call it **three times** so that we can test that the cache is working. We'll call it first with `1`, then once with `2`, then again a third time with `1`.
+
+```js
+// memoize.test.js
+
+test('should return a cached result if the function has been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	memoizedFn(1);
+	memoizedFn(2);
+	const result = memoizedFn(1);
+});
+```
+
+Finally, we can write our assertions. We want to make sure that `plus1` **isn't called** the second time.
+
+```js
+// memoize.test.js
+
+test('should return a cached result if the function has been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	memoizedFn(1);
+	memoizedFn(2);
+	const result = memoizedFn(1);
+
+	expect(result).toEqual(2);
+	expect(plus1).toHaveBeenCalledTimes(2);
+});
+```
+
+For this test we only want to assert two things:
+
+1. That `memoizedFn` still returns the correct result (`.toEqual(2)`).
+2. That `plus1` was only called twice (once with `1`, once with `2`, the third time hit the cache).
+
+## Bonus BONUS: custom cache keys 🤯
+
+As a second bonus, let's add the ability to customize how the cache key is created.
+
+Currently, `memoize` just takes the first argument and uses that as a cache key. This is good enough for a lot of functions, but sometimes you need something a little more robust.
+
+We'll add an optional second argument to `memoize` called `getCacheKey`. As a default we're going to use the first argument, like we had before.
+
+```js
+const defaultGetCacheKey = (...args) => args[0];
+
+const memoize = (fn, getCacheKey = defaultGetCacheKey) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = args[0];
+
+		if (cache.has(cacheKey)) {
+			return cache.get(cacheKey);
+		}
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+Then, all that's left to do is swap `const cacheKey = args[0]` for our new function.
+
+```js
+const memoize = (fn, getCacheKey = (...args) => args[0]) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = getCacheKey(...args);
+
+		if (cache.has(cacheKey)) {
+			return cache.get(cacheKey);
+		}
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+Now, instead of only using the first argument to the memoized function as a cache key, we can use whatever we want!
+
+For example, instead of using the first argument to `add`, we can create a string containing both numbers.
+
+```js
+const add = (a, b) => a + b;
+const memoizedAdd = memoize(add, (a, b) => `${a}-${b}`);
+
+memoizedAdd(1, 3);
+memoizedAdd(1, 2);
+memoizedAdd(1, 4);
+
+// hits the cache for the key "1-2"
+memoizedAdd(1, 2);
+```
+
+Finally, let's add a test for this new functionality.
+
+```js
+// memoize.test.js
+
+test('should allow customization of the cache key', () => {
+	const add = jest.fn((a, b) => a + b);
+	const getCacheKey = (a, b) => `${a}-${b}`;
+	const memoized = memoize(add, getCacheKey);
+
+	memoized(1, 3);
+	memoized(1, 2);
+	memoized(1, 4);
+	const result = memoized(1, 2);
+
+	expect(result).toEqual(3);
+	expect(add).toHaveBeenCalledTimes(3);
+});
+```
+
+In this test we set up our memoized function and then run it three times with fresh input. In each of these first three calls, the _first argument is the same_. This way we can make sure that the cache key is actually changing.
+
+On the fourth time we run the memoized function with arguments that it has already received before.
+
+Lastly, we make our assertions—we'll assert that the fourth time returns the correct result (`3` and not the result of `memoized(1,3)`), and we'll assert that `add` only got called 3 times.
+
+---
+
+## Conclusion
+
+I hope that this was helpful! I know for myself, I learn a ton when I reimplement stuff that I commonly use from scratch.
+
+Feel free to reach out to me on [Twitter](https://twitter.com/benjamminj) or my [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (reference this article so I know you're not a LinkedIn bot 😱 ).

--- a/apps/website-sv/src/content/writing/writing-less.md
+++ b/apps/website-sv/src/content/writing/writing-less.md
@@ -1,0 +1,21 @@
+---
+title: Writing less, and that's ok
+description: I'm learning to be easier on myself, slowly prune thoughts into posts, and write in smaller bursts.
+date: 2025-05-13
+tags:
+  - writing
+---
+
+I'm writing less these days.
+
+For the past few years, I've felt guilty about writing fewer blog posts. Earlier in my career, I published ~monthly; now it's more sporadic.
+
+Frankly, I have less gas in the tank to spend on writing. Back in 2020, I had a major burnout that left me unable to even write code for a while. Fast forward to today — I have 2 young children and less time overall to write blog posts.
+
+Plus, the things I want to write about are trickier: deep technical dives, philosophical musings about software development, and real-world stories. All of these require more effort than a simple tutorial. Pair that with my post-burnout energy and finishing posts feels more daunting.
+
+Finally, this website’s former design didn’t inspire me to write. I know "rewrite your portfolio" is a bit of an engineer trope, but this latest iteration makes me want to finish (or restart) some of those drafts.
+
+It’s tempting to compare yourself to other writers, especially prolific ones. But it's not healthy. We each have an amount we can give, and mine is smaller than it used to be.
+
+I'm writing less these days, and I'm ok with that. I'm learning to be easier on myself, slowly prune thoughts into posts, and write in smaller bursts.

--- a/apps/website-sv/src/lib/a.svelte
+++ b/apps/website-sv/src/lib/a.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from "svelte";
-	import { type HTMLAnchorAttributes } from "svelte/elements";
+	import type { HTMLAnchorAttributes } from "svelte/elements";
 	import { cn } from "./cn";
 
 	type Props = HTMLAnchorAttributes & {
@@ -10,12 +10,14 @@
 	let { children, ...props }: Props = $props();
 </script>
 
-<a
-	{...props}
-	class={cn(
-		"underline text-body font-bold cursor-pointer text-fg-link hover:text-fg-link-hover",
-		props.class,
-	)}
->
-	{@render children()}
-</a>
+<span>
+	<a
+		{...props}
+		class={cn(
+			"underline text-body font-bold cursor-pointer text-fg-link hover:text-fg-link-hover",
+			props.class,
+		)}
+	>
+		{@render children()}
+	</a>
+</span>

--- a/apps/website-sv/src/lib/background-code-pattern.svelte
+++ b/apps/website-sv/src/lib/background-code-pattern.svelte
@@ -17,7 +17,7 @@
 
 <div
 	class={cn(
-		"absolute inset-0 overflow-hidden break-all transition-colors duration-500",
+		"absolute inset-0 -z-10 overflow-hidden break-all transition-colors duration-500",
 		reps > 0 ? "text-fg/4" : "text-transparent",
 	)}
 >

--- a/apps/website-sv/src/lib/callout.svelte
+++ b/apps/website-sv/src/lib/callout.svelte
@@ -1,0 +1,164 @@
+<!-- import type { CSSProperties, ReactNode } from "react";
+import { cn } from "./cn";
+
+export const CALLOUT_VARIANTS = [
+	"NOTE",
+	"TIP",
+	"IMPORTANT",
+	"WARNING",
+	"CAUTION",
+] as const;
+
+type CalloutVariant = Lowercase<(typeof CALLOUT_VARIANTS)[number]>;
+
+type CalloutProps = {
+	variant: CalloutVariant;
+	children: ReactNode;
+	className?: string;
+};
+
+type CalloutVariantStyleConfig = {
+	icon: string;
+	colorGroupMapping: "success" | "warning" | "info" | "error" | "important";
+};
+
+const CALLOUT_VARIANT_STYLES: Record<
+	CalloutVariant,
+	CalloutVariantStyleConfig
+> = {
+	note: {
+		icon: "💬",
+		colorGroupMapping: "info",
+	},
+	tip: {
+		icon: "💡",
+		colorGroupMapping: "success",
+	},
+	important: {
+		icon: "📣",
+		colorGroupMapping: "important",
+	},
+	warning: {
+		icon: "⚠️",
+		colorGroupMapping: "warning",
+	},
+	caution: {
+		icon: "🚨",
+		colorGroupMapping: "error",
+	},
+};
+
+export function Callout({ variant, children, className }: CalloutProps) {
+	const config = CALLOUT_VARIANT_STYLES[variant];
+
+	return (
+		<blockquote
+			data-variant={variant}
+			style={
+				{
+					"--callout-bg": `var(--color-${config.colorGroupMapping}-bg)`,
+					"--callout-bg-emphasis": `var(--color-${config.colorGroupMapping}-bg-emphasis)`,
+					"--callout-border": `var(--color-${config.colorGroupMapping}-border)`,
+					"--callout-fg-link": `var(--color-${config.colorGroupMapping}-fg-link)`,
+					"--callout-fg-link-hover": `var(--color-${config.colorGroupMapping}-fg-link-hover)`,
+					"--callout-fg-muted": `var(--color-${config.colorGroupMapping}-fg-muted)`,
+				} as CSSProperties
+			}
+			className={cn(
+				"bg-(--callout-bg)/50 backdrop-blur-[1px] text-fg outline-2 rounded-xs outline-(--callout-border)/50",
+				"[&_a]:text-(--callout-fg-link) [&_a:hover]:text-(--callout-fg-link-hover)",
+				"[&_code]:bg-(--callout-bg-emphasis)/10",
+				"p-line [&_:last-child]:mb-0",
+				className,
+			)}
+		>
+			<div className="grid grid-cols-[auto_1fr] gap-3">
+				<div aria-label={variant} className="not-italic font-serif">
+					{config.icon}
+				</div>
+				<div>{children}</div>
+			</div>
+		</blockquote>
+	);
+} -->
+
+<script module lang="ts">
+	import type { Snippet } from "svelte";
+	import { cn } from "./cn";
+
+	export const CALLOUT_VARIANTS = [
+		"NOTE",
+		"TIP",
+		"IMPORTANT",
+		"WARNING",
+		"CAUTION",
+	] as const;
+
+	export type CalloutVariant = Lowercase<(typeof CALLOUT_VARIANTS)[number]>;
+
+	type CalloutVariantStyleConfig = {
+		icon: string;
+		colorGroupMapping: "success" | "warning" | "info" | "error" | "important";
+	};
+
+	const CALLOUT_VARIANT_STYLES: Record<
+		CalloutVariant,
+		CalloutVariantStyleConfig
+	> = {
+		note: {
+			icon: "💬",
+			colorGroupMapping: "info",
+		},
+		tip: {
+			icon: "💡",
+			colorGroupMapping: "success",
+		},
+		important: {
+			icon: "📣",
+			colorGroupMapping: "important",
+		},
+		warning: {
+			icon: "⚠️",
+			colorGroupMapping: "warning",
+		},
+		caution: {
+			icon: "🚨",
+			colorGroupMapping: "error",
+		},
+	};
+</script>
+
+<script lang="ts">
+	type CalloutProps = {
+		variant: CalloutVariant;
+		children: Snippet;
+		class?: string;
+	};
+
+	let { variant, children, class: className }: CalloutProps = $props();
+	let config = $derived(CALLOUT_VARIANT_STYLES[variant]);
+</script>
+
+<blockquote
+	data-variant={variant}
+	style:--callout-bg="var(--color-{config.colorGroupMapping}-bg)"
+	style:--callout-bg-emphasis="{`var(--color-${config.colorGroupMapping}-bg-emphasis)`},"
+	style:--callout-border={`var(--color-${config.colorGroupMapping}-border)`}
+	style:--callout-fg-link={`var(--color-${config.colorGroupMapping}-fg-link)`}
+	style:--callout-fg-link-hover={`var(--color-${config.colorGroupMapping}-fg-link-hover)`}
+	style:--callout-fg-muted={`var(--color-${config.colorGroupMapping}-fg-muted)`}
+	class={cn(
+		"bg-(--callout-bg)/50 backdrop-blur-[1px] text-fg outline-2 rounded-xs outline-(--callout-border)/50",
+		"[&_a]:text-(--callout-fg-link) [&_a:hover]:text-(--callout-fg-link-hover)",
+		"[&_code]:bg-(--callout-bg-emphasis)/10",
+		"p-line **:last:mb-0",
+		className,
+	)}
+>
+	<div class="grid grid-cols-[auto_1fr] gap-3">
+		<div aria-label={variant} class="not-italic font-serif">
+			{config.icon}
+		</div>
+		<div>{@render children()}</div>
+	</div>
+</blockquote>

--- a/apps/website-sv/src/lib/code.svelte
+++ b/apps/website-sv/src/lib/code.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { getPreContext } from "./pre.svelte";
+	import type { Snippet } from "svelte";
+	import { cn } from "./cn";
+
+	const preformatted = getPreContext();
+	type Props = HTMLAttributes<HTMLElement> & {
+		children: Snippet;
+	};
+	const {
+		children,
+		class: classNameFromProps,
+		...properties
+	}: Props = $props();
+	const classNames = preformatted
+		? undefined
+		: "inline-block bg-bg-emphasis/10 backdrop-blur-xs text-fg wrap-break-word before:content-['`'] before:font-bold before:text-fg/60 after:content-['`'] after:font-bold after:text-fg/60 rounded-xs";
+</script>
+
+<code class={cn(classNames, classNameFromProps)} {...properties}
+	>{@render children()}
+</code>

--- a/apps/website-sv/src/lib/h.svelte
+++ b/apps/website-sv/src/lib/h.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "./cn";
+
+	export type HLevel = 1 | 2 | 3 | 4 | 5 | 6;
+	type HProps = HTMLAttributes<HTMLHeadingElement> & {
+		level?: HLevel;
+		children: Snippet;
+		/**
+		 * - `prefixed` will add a `#` prefix to the heading based on its level.
+		 * - `bare` will not add a prefix, just the `h` tag & default typographic styles.
+		 */
+		variant?: "prefixed" | "bare";
+	};
+
+	let {
+		level: controlledLevel = 2,
+		children,
+		variant = "prefixed",
+		...props
+	}: HProps = $props();
+
+	let level = $derived(Math.min(Math.max(controlledLevel, 1), 6) as HLevel);
+	let tag = $derived(`h${level}`);
+</script>
+
+<svelte:element
+	this={tag}
+	data-content={variant === "prefixed" ? "#".repeat(level) : undefined}
+	{...props}
+	class={cn(
+		"text-heading before:text-fg-muted",
+		variant === "prefixed" &&
+			"before:content-[attr(data-content)] before:mr-ch before:no-underline before:inline-block",
+		props.class,
+	)}
+>
+	{@render children()}
+</svelte:element>

--- a/apps/website-sv/src/lib/markdown-renderer-layout.svelte
+++ b/apps/website-sv/src/lib/markdown-renderer-layout.svelte
@@ -1,0 +1,7 @@
+<svelte:options runes={false} />
+
+<script module>
+	// import a from "./a.svelte";
+
+	// export { a };
+</script>

--- a/apps/website-sv/src/lib/markdown.svelte
+++ b/apps/website-sv/src/lib/markdown.svelte
@@ -1,32 +1,93 @@
 <script lang="ts">
-	import type { Parent } from "mdast";
+	import type { CalloutVariant } from "./callout.svelte";
+
+	import type { Element, Root } from "hast";
 	import A from "./a.svelte";
+	import Callout from "./callout.svelte";
+	import H, { type HLevel } from "./h.svelte";
+	import Pre from "./pre.svelte";
+	import Code from "./code.svelte";
 
 	type Props = {
-		ast: Parent;
+		ast: Root;
 	};
 	let { ast }: Props = $props();
 </script>
 
-{#snippet renderNode(ast: Parent)}
+{#snippet renderNode(ast: Element)}
 	{#each ast.children as node}
-		{#if node.type === "paragraph"}
-			<p>{@render renderNode(node)}</p>
-		{:else if node.type === "heading"}
-			<!-- TODO: dynamic H tag -->
-			<h2>
+		{#if node.type === "text"}
+			{node.value}
+		{:else if (node.type === "comment")}
+		  <!-- 
+				Don't render comments, we need to check this logical branch for the rest of
+				the renderer to be typesafe.
+			-->
+		{:else if (node.type === "raw")}
+			{@html node.value}
+		{:else if node.tagName === "ol"}
+			<ol
+				class="my-line list-decimal [&_ol]:list-[lower-alpha] pl-7 space-y-line"
+			>
 				{@render renderNode(node)}
-			</h2>
-		{:else if node.type === "link"}
-			<A href={node.url}>
+			</ol>
+		{:else if node.tagName === "ul"}
+			<ul
+				class="my-line list-disc [&_ul]:list-[circle] pl-5 [&_li]:pl-2 space-y-line"
+			>
+				{@render renderNode(node)}
+			</ul>
+		{:else if node.tagName === "a"}
+			<A href={node.properties.href as string}>
 				{@render renderNode(node)}
 			</A>
-		{:else if node.type === "text"}
-			{node.value}
+		{:else if ["h1", "h2", "h3", "h4", "h5", "h6"].includes(node.tagName)}
+				{const level = parseInt(node.tagName[1]) as HLevel}
+				<H level={level} variant="prefixed">
+					{@render renderNode(node)}
+				</H>
+		{:else if node.tagName === 'blockquote'}
+			{#if node.properties?.["data-variant"]}
+				{const variant = $derived(
+					node.properties["data-variant"] as CalloutVariant,
+				)}
+
+				<Callout variant={variant}>
+					{@render renderNode(node)}
+				</Callout>
+			{:else}
+			  <blockquote
+					class="my-line px-4 italic bg-bg-muted/40 backdrop-blur-[1px] border-l-4 border-l-border ring-1 ring-inset ring-bg-muted rounded-xs rounded-l-[1px] space-y-line py-line"
+				>
+					{@render renderNode(node)}
+				</blockquote>
+			{/if}
+		{:else if node.tagName === 'pre'}
+			<Pre {...node.properties}>{@render renderNode(node)}</Pre>
+		{:else if node.tagName === 'code'}
+			<Code>{@render renderNode(node)}</Code>
+		{:else if node.tagName === 'hr'}
+			<hr class="relative h-auto my-line-2 text-center text-fg-muted border-none before:content-['*_*_*'] before:text-heading" />
+		{:else if node.tagName === 'table'}
+			<table class="border">{@render renderNode(node)}</table>
+		{:else if node.tagName === 'thead'}
+			<thead class="group/thead">{@render renderNode(node)}</thead>
+		{:else if node.tagName === 'td'}
+			<td class="border-collapse border align-baseline py-[calc(var(--line-height-base)/2-0.5px)] px-3">
+				{@render renderNode(node)}
+			</td>
+		{:else if node.tagName}
+			{#if node.children && node.children.length > 0}
+				<svelte:element this={node.tagName} {...node.properties}>
+					{@render renderNode(node)}
+				</svelte:element>
+			{:else}
+				<svelte:element this={node.tagName} {...node.properties} />
+			{/if}
 		{/if}
 	{/each}
 {/snippet}
 
 <div class="text-body mx-0 max-w-prose px-0 space-y-line">
-	{@render renderNode(ast)}
+	{@render renderNode(ast as unknown as Element)}
 </div>

--- a/apps/website-sv/src/lib/markdown.svelte
+++ b/apps/website-sv/src/lib/markdown.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { Parent } from "mdast";
+	import A from "./a.svelte";
+
+	type Props = {
+		ast: Parent;
+	};
+	let { ast }: Props = $props();
+</script>
+
+{#snippet renderNode(ast: Parent)}
+	{#each ast.children as node}
+		{#if node.type === "paragraph"}
+			<p>{@render renderNode(node)}</p>
+		{:else if node.type === "heading"}
+			<!-- TODO: dynamic H tag -->
+			<h2>
+				{@render renderNode(node)}
+			</h2>
+		{:else if node.type === "link"}
+			<A href={node.url}>
+				{@render renderNode(node)}
+			</A>
+		{:else if node.type === "text"}
+			{node.value}
+		{/if}
+	{/each}
+{/snippet}
+
+<div class="text-body mx-0 max-w-prose px-0 space-y-line">
+	{@render renderNode(ast)}
+</div>

--- a/apps/website-sv/src/lib/posts-service.server.ts
+++ b/apps/website-sv/src/lib/posts-service.server.ts
@@ -1,6 +1,5 @@
 import fm from "front-matter";
 import { glob } from "glob";
-import type { Root } from "mdast";
 import rehypePrettyCode from "rehype-pretty-code";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
@@ -11,6 +10,9 @@ import { z } from "zod";
 import { readFile } from "./read-file";
 import { rehypeCallouts } from "./rehype-callouts";
 import { slimAst } from "./rehype-slim-hast";
+import rehypeStringify from "rehype-stringify";
+import { fromHtml } from "hast-util-from-html";
+import rehypeParse from "rehype-parse";
 
 /**
  * Parses a date object into a JSON-serializable string, formatted as yyyy-mm-dd.
@@ -130,7 +132,7 @@ async function transformToStaticHTML(markdown: string) {
 
 // TODO: some other service (markdown?)
 export async function transformToAst(markdown: string) {
-	const ast = unified()
+	const processor = unified()
 		.use(remarkParse)
 		.use(remarkGfm)
 		.use(remarkRehype)
@@ -140,11 +142,15 @@ export async function transformToAst(markdown: string) {
 			defaultLang: "plaintext",
 			keepBackground: false,
 		})
-		.parse(markdown);
+		.use(() => slimAst);
 
-	slimAst(ast);
+	const mdast = processor.parse(markdown);
+	const hast = processor.run(mdast);
+	// const parsed = fromHtml(ast.value);
+	// slimAst(ast);
 
-	return ast;
+	// return hyped;
+	return hast;
 }
 
 /**

--- a/apps/website-sv/src/lib/posts-service.server.ts
+++ b/apps/website-sv/src/lib/posts-service.server.ts
@@ -1,0 +1,191 @@
+import fm from "front-matter";
+import { glob } from "glob";
+import type { Root } from "mdast";
+import rehypePrettyCode from "rehype-pretty-code";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import type { ZodTypeAny } from "zod";
+import { z } from "zod";
+import { readFile } from "./read-file";
+import { rehypeCallouts } from "./rehype-callouts";
+import { slimAst } from "./rehype-slim-hast";
+
+/**
+ * Parses a date object into a JSON-serializable string, formatted as yyyy-mm-dd.
+ */
+const FormattedDateSchema = z.date().transform((date) => {
+	const iso = date.toISOString();
+
+	// We split the ISO string into its components using a regex to avoid timezone conversions
+	// that occur when using date.getMonth, date.getDay, etc. This makes sure that the date
+	// is stable (always in GMT timezone) regardless of where the build was run.
+	const [y, m, d] = iso.split(/[-T]/);
+	return [y, m?.padStart(2, "0"), d?.padStart(2, "0")].join("-");
+});
+
+/**
+ * All of the metadata about the blog post. This mostly comes from the front-matter
+ * of the file, but some items can be derived from the file name.
+ */
+const PostMetadataSchema = z
+	.object({
+		slug: z.string(),
+		title: z.string(),
+		date: FormattedDateSchema,
+		lastUpdated: FormattedDateSchema.optional(),
+		description: z.string().optional(),
+		tags: z.array(z.string()).default([]),
+		link: z.string().optional(),
+		publisher: z.string().optional(),
+	})
+	.transform(({ lastUpdated, date, ...rest }) => ({
+		...rest,
+		date: lastUpdated ?? date,
+	}));
+
+/**
+ * The post content itself, parsed into a HTML AST. This schema should usually be
+ * composed with the metadata schema to create a full "Post" object.
+ */
+const PostContentSchema = z.object({
+	// @todo: This should be the type of the HAST, but since that's recursive you
+	// can easily get into an infinite parsing loop.
+	content: z.any(),
+});
+
+/**
+ * A single post, with metadata and parsed HAST content.
+ */
+const PostSchema = z.intersection(PostContentSchema, PostMetadataSchema);
+
+export type Post = z.infer<typeof PostSchema>;
+
+/**
+ * Responsible for reading & formatting post data.
+ *
+ * TODO: set up a cache to make retrieval of posts a little faster
+ * when we get up large builds...
+ */
+/**
+ * Fetches the raw posts from the file system.
+ */
+async function fetchRaw() {
+	const posts = await glob("**/content/writing/**/*.md");
+	return posts;
+}
+
+/**
+ * Converts a file path into a slug. This is used to generate the slug for a
+ * post from its file name.
+ */
+function slugify(path: string) {
+	const [_, tail] = path.split("content/writing/");
+	return tail.replace(".md", "");
+}
+
+/**
+ * Given a path and raw content, parses the post into a Post object.
+ * Optionally, can include the raw HTML content of the post.
+ */
+async function parse({
+	path,
+	raw,
+	include = [],
+}: {
+	path: string;
+	raw: string;
+	include?: "html"[];
+}) {
+	const slug = slugify(path);
+	const { attributes, body } = fm<Record<string, string>>(raw);
+	const post: Record<string, unknown> = {
+		slug,
+		...attributes,
+	};
+
+	let schema: ZodTypeAny = PostMetadataSchema;
+
+	// Optionally allow the content to be included as pre-parsed HTML
+	// for the RSS feed.
+	if (include.includes("html")) {
+		const html = await transformToStaticHTML(body);
+		schema = z.intersection(PostMetadataSchema, z.object({ html: z.string() }));
+		post.html = html;
+	}
+
+	const hast = await transformToAst(body);
+
+	return schema.parseAsync(post) as Promise<Post>;
+}
+
+/**
+ * Pipeline to take raw Markdown and turn it into a HTML string. This should only be used as
+ * part of the RSS feed.
+ */
+async function transformToStaticHTML(markdown: string) {
+	// TODO: use rehype to render it out to MD?
+}
+
+// TODO: some other service (markdown?)
+export async function transformToAst(markdown: string) {
+	const ast = unified()
+		.use(remarkParse)
+		.use(remarkGfm)
+		.use(remarkRehype)
+		.use(rehypeCallouts)
+		.use(rehypePrettyCode, {
+			theme: "rose-pine",
+			defaultLang: "plaintext",
+			keepBackground: false,
+		})
+		.parse(markdown);
+
+	slimAst(ast);
+
+	return ast;
+}
+
+/**
+ *
+ * Lists all posts, optionally including additional data like HTML.
+ */
+async function list({ include = [] }: { include?: "html"[] } = {}): Promise<
+	(Post & { html?: string })[]
+> {
+	const rawPosts = await fetchRaw();
+
+	const formatted = await Promise.all(
+		rawPosts.map((path) =>
+			readFile(path).then((raw) => parse({ path, raw, include })),
+		),
+	);
+
+	formatted.sort((a, b) => b.date.localeCompare(a.date));
+	return formatted;
+}
+
+/**
+ * Retrieves a single post by its slug.
+ */
+async function get(slug: string) {
+	const rawPosts = await fetchRaw();
+	const path = rawPosts.find((path) => slugify(path) === slug);
+	if (!path) {
+		throw new Error(`Post not found: ${slug}`);
+	}
+
+	const raw = await readFile(path);
+	const metadata = await parse({ path, raw });
+	const { body } = fm<Record<string, string>>(raw);
+	return {
+		...metadata,
+		body,
+	};
+}
+
+export const PostService = {
+	list,
+	get,
+};

--- a/apps/website-sv/src/lib/pre.svelte
+++ b/apps/website-sv/src/lib/pre.svelte
@@ -1,0 +1,25 @@
+<script module lang="ts">
+	import { createContext, type Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+	let preContext = createContext<boolean>();
+	const [getPreContextUnsafe, setPreContext] = preContext;
+	export function getPreContext() {
+		try {
+			return getPreContextUnsafe();
+		} catch (error) {
+			return false;
+		}
+	}
+</script>
+
+<script lang="ts">
+	type Props = HTMLAttributes<HTMLPreElement> & {
+		children: Snippet;
+	};
+	const { children, ...properties }: Props = $props();
+	setPreContext(true);
+	const className =
+		"relative p-line overflow-auto rounded-xs bg-gray-900 text-white";
+</script>
+
+<pre class={className} {...properties}>{@render children()}</pre>

--- a/apps/website-sv/src/lib/read-file.ts
+++ b/apps/website-sv/src/lib/read-file.ts
@@ -1,0 +1,14 @@
+import { glob } from "glob";
+import fs from "node:fs/promises";
+
+export const readFile = async (contentPath: string, extension = "md") => {
+	const map = await glob(`**/content/**/*.${extension}`);
+	const filePath = map.findIndex((path) => path.endsWith(contentPath));
+
+	if (filePath < 0) {
+		throw new Error(`No such file: ${contentPath}`);
+	}
+
+	const raw = await fs.readFile(map[filePath], "utf-8");
+	return raw;
+};

--- a/apps/website-sv/src/lib/rehype-callouts.ts
+++ b/apps/website-sv/src/lib/rehype-callouts.ts
@@ -1,0 +1,52 @@
+import { visit } from "unist-util-visit";
+import type { Element, Root, Text } from "hast";
+
+// TODO: constant / separate package
+export const CALLOUT_VARIANTS = [
+	"NOTE",
+	"TIP",
+	"IMPORTANT",
+	"WARNING",
+	"CAUTION",
+] as const;
+
+
+/**
+ * Adds parsing for Github-style callouts to the HAST tree.
+ */
+export function rehypeCallouts() {
+	return (tree: Root) => {
+		visit(tree, "element", (node: Element) => {
+			if (node.tagName !== "blockquote") return;
+
+			let variant: string | undefined;
+
+			// Visit paragraphs within blockquote
+			visit(node, "element", (child: Element, _index, parent) => {
+				if (child.tagName !== "p" || parent !== node) return;
+
+				// Visit text nodes within paragraph
+				visit(child, "text", (text: Text) => {
+					const match = CALLOUT_VARIANTS.find(
+						(variant) => text.value === `[!${variant}]`,
+					);
+					if (match) {
+						variant = match.toLowerCase();
+						// Remove the paragraph containing directive
+						node.children = node.children.filter((n) => n !== child);
+						// Stop visiting, we found what we needed.
+						return;
+					}
+				});
+
+				// Stop after finding first match
+				if (variant) return;
+			});
+
+			if (variant) {
+				node.properties = node.properties || {};
+				node.properties["data-variant"] = variant;
+			}
+		});
+	};
+}

--- a/apps/website-sv/src/lib/rehype-callouts.ts
+++ b/apps/website-sv/src/lib/rehype-callouts.ts
@@ -10,7 +10,6 @@ export const CALLOUT_VARIANTS = [
 	"CAUTION",
 ] as const;
 
-
 /**
  * Adds parsing for Github-style callouts to the HAST tree.
  */

--- a/apps/website-sv/src/lib/rehype-slim-hast.ts
+++ b/apps/website-sv/src/lib/rehype-slim-hast.ts
@@ -1,4 +1,5 @@
-import type { Root } from "mdast";
+import type { Root, RootContent } from "hast";
+import { filter } from "unist-util-filter";
 import { visit } from "unist-util-visit";
 
 export function slimAst(tree: Root) {
@@ -7,4 +8,11 @@ export function slimAst(tree: Root) {
 	visit(tree, (node) => {
 		delete node.position;
 	});
+	// const filtered = filter(tree, (node) => {
+	// 	const n = node as RootContent;
+	// 	if (n.type === "text" && n.value === "\n") return false;
+	// 	return true;
+	// });
+
+	// return filtered;
 }

--- a/apps/website-sv/src/lib/rehype-slim-hast.ts
+++ b/apps/website-sv/src/lib/rehype-slim-hast.ts
@@ -1,0 +1,10 @@
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
+
+export function slimAst(tree: Root) {
+	delete tree.position;
+
+	visit(tree, (node) => {
+		delete node.position;
+	});
+}

--- a/apps/website-sv/src/routes/+layout.svelte
+++ b/apps/website-sv/src/routes/+layout.svelte
@@ -2,46 +2,25 @@
 	import "./layout.css";
 	import favicon from "$lib/assets/favicon.svg";
 	import BackgroundCodePattern from "$lib/background-code-pattern.svelte";
+	import A from "$lib/a.svelte";
 
 	let { children } = $props();
 </script>
 
-<svelte:head><link rel="icon" href={favicon} /></svelte:head>
+<svelte:head>
+	<link rel="icon" href={favicon} />
+</svelte:head>
 
-<div class="font-mono bg-bg text-fg text-body min-h-screen relative">
+<div class="z-0 font-mono bg-bg text-fg text-body min-h-screen relative">
 	<BackgroundCodePattern />
 
-	{@render children()}
+	<div class="p-line xl:p-line-2 2xl:p-line-3">
+		<header>
+			<A href="/" class="no-underline hover:underline lowercase text-heading">
+				Benjamin Johnson
+			</A>
+		</header>
+
+		<main class="pt-line-3">{@render children()}</main>
+	</div>
 </div>
-
-<style>
-	/* jetbrains-mono-latin-wght-normal */
-	@font-face {
-		font-family: "JetBrains Mono Variable";
-		font-style: normal;
-		font-display: swap;
-		font-weight: 100 800;
-		src: url(@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2)
-			format("woff2-variations");
-		unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-			U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-			U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-	}
-
-	/* jetbrains-mono-latin-wght-italic */
-	@font-face {
-		font-family: "JetBrains Mono Variable";
-		font-style: italic;
-		font-display: swap;
-		font-weight: 100 800;
-		src: url(@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-italic.woff2)
-			format("woff2-variations");
-		unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-			U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191,
-			U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-	}
-
-	:global(:root) {
-		--font-jetbrains-mono: "JetBrains Mono Variable", monospace;
-	}
-</style>

--- a/apps/website-sv/src/routes/+page.server.ts
+++ b/apps/website-sv/src/routes/+page.server.ts
@@ -1,9 +1,9 @@
-import { PostService, transformToAst } from "$lib/posts-service.server";
+import { transformToAst } from "$lib/posts-service.server";
 import { readFile } from "$lib/read-file";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async () => {
-	const md = await readFile("markdown-test.md");
+	const md = await readFile("intro.md");
 	const ast = await transformToAst(md);
 
 	return { ast };

--- a/apps/website-sv/src/routes/+page.server.ts
+++ b/apps/website-sv/src/routes/+page.server.ts
@@ -1,0 +1,10 @@
+import { PostService, transformToAst } from "$lib/posts-service.server";
+import { readFile } from "$lib/read-file";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async () => {
+	const md = await readFile("markdown-test.md");
+	const ast = await transformToAst(md);
+
+	return { ast };
+};

--- a/apps/website-sv/src/routes/+page.svelte
+++ b/apps/website-sv/src/routes/+page.svelte
@@ -1,9 +1,25 @@
-<script>
+<script lang="ts">
 	import A from "$lib/a.svelte";
+	import { cn } from "$lib/cn";
+	import Markdown from "$lib/markdown.svelte";
+	import type { PageProps } from "./$types";
+
+	let { data }: PageProps = $props();
 </script>
 
-<h1>Welcome to SvelteKit</h1>
-<p>
-	Visit <A href="https://svelte.dev/docs/kit">THAT PAGE</A> to read
-	<i>the documentation for the thingy</i>
-</p>
+<Markdown ast={data.ast} />
+
+<nav
+	class={cn(
+		"flex flex-wrap gap-x-ch pt-line",
+		"*:not-last:after:content-['/']",
+		"*:not-last:after:pl-ch",
+		"*:not-last:after:text-fg-muted",
+		"*:not-last:after:no-underline",
+	)}
+>
+	<A href="/writing">writing</A>
+	<A href="/about">about</A>
+	<A target="_blank" rel="noopener noreferrer" href="/links/bluesky">bluesky</A>
+	<A target="_blank" rel="noopener noreferrer" href="/links/email">email</A>
+</nav>

--- a/apps/website-sv/src/routes/layout.css
+++ b/apps/website-sv/src/routes/layout.css
@@ -2,6 +2,40 @@
 
 /**
  * -----------------------------------------------------------------------------
+ * FONTS
+ * -----------------------------------------------------------------------------
+ */
+
+/* jetbrains-mono-latin-wght-normal */
+@font-face {
+	font-family: "JetBrains Mono Variable";
+	font-style: normal;
+	font-display: swap;
+	font-weight: 100 800;
+	src: url(@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2)
+		format("woff2-variations");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
+		U+2215, U+FEFF, U+FFFD;
+}
+
+/* jetbrains-mono-latin-wght-italic */
+@font-face {
+	font-family: "JetBrains Mono Variable";
+	font-style: italic;
+	font-display: swap;
+	font-weight: 100 800;
+	src: url(@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-italic.woff2)
+		format("woff2-variations");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
+		U+2215, U+FEFF, U+FFFD;
+}
+
+/**
+ * -----------------------------------------------------------------------------
  * COLORS
  * -----------------------------------------------------------------------------
  */
@@ -204,6 +238,7 @@
 	---default-font-mono-fallback:
 		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
 		"Courier New", monospace;
+	--font-jetbrains-mono: "JetBrains Mono Variable";
 	--line-height-base: 1.5rem;
 
 	/* General type configs */

--- a/apps/website-sv/svelte.config.js
+++ b/apps/website-sv/svelte.config.js
@@ -14,8 +14,8 @@ const config = {
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter(),
 	},
-	preprocess: [mdsvex({ extensions: [".svx", ".md"] })],
-	extensions: [".svelte", ".svx", ".md"],
+	preprocess: [],
+	extensions: [".svelte"],
 };
 
 export default config;

--- a/apps/website/src/lib/code.tsx
+++ b/apps/website/src/lib/code.tsx
@@ -35,7 +35,7 @@ export const Code = ({
 	}
 
 	return (
-		<code className="inline-block bg-bg-emphasis/10 backdrop-blur-xs text-fg break-words before:content-['`'] before:font-bold before:text-fg/60 after:content-['`'] after:font-bold after:text-fg/60 rounded-xs">
+		<code className="inline-block bg-bg-emphasis/10 backdrop-blur-xs text-fg wrap-break-word before:content-['`'] before:font-bold before:text-fg/60 after:content-['`'] after:font-bold after:text-fg/60 rounded-xs">
 			{children}
 		</code>
 	);

--- a/packages/content/about.md
+++ b/packages/content/about.md
@@ -1,0 +1,8 @@
+`Thanks for popping into my little corner of the internet.
+
+I build large scale frontend web applications, specifically with an eye towards progressive enhancement, accessibility, and simplicity. I currently work as a software engineer at [Sublime Security](https://sublimesecurity.com/).
+
+I'm currently based out of the greater Seattle area where my family and I love the wet winters and beautiful PNW summers.
+
+Wanna connect? Reach out on [Bluesky](/links/bluesky) or shoot me an [email](/links/email), I'd love to hear from you.
+`

--- a/packages/content/clippings.json
+++ b/packages/content/clippings.json
@@ -1,0 +1,62 @@
+[
+	{
+		"name": "The Wrong Abstraction",
+		"url": "https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction",
+		"tags": ["software-engineering"]
+	},
+	{
+		"name": "A Codebase is an Organism",
+		"url": "https://meltingasphalt.com/a-codebase-is-an-organism",
+		"tags": ["software-engineering", "tech-debt", "philosophy"]
+	},
+	{
+		"name": "On the Spectrum of Abstraction (YouTube)",
+		"url": "https://www.youtube.com/watch?v=mVVNJKv9esE",
+		"tags": ["software-engineering", "philosophy"]
+	},
+	{
+		"name": "The Canvas Cares Not",
+		"url": "https://www.neversaw.us/2022/01/30/the-canvas-cares-not",
+		"tags": ["software-engineering", "philosophy"]
+	},
+	{
+		"name": "On Being A Senior Engineer",
+		"url": "https://www.kitchensoap.com/2012/10/25/on-being-a-senior-engineer/",
+		"tags": ["software-engineering", "career"]
+	},
+	{
+		"name": "Parse, don't validate",
+		"url": "https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/",
+		"tags": ["software-engineering"]
+	},
+	{
+		"name": "Small CLs",
+		"url": "https://google.github.io/eng-practices/review/developer/small-cls.html",
+		"tags": ["software-engineering", "teamwork", "pull-requests"]
+	},
+	{
+		"name": "How Complex Systems Fail",
+		"url": "https://how.complexsystems.fail/",
+		"tags": ["software-engineering", "philosophy"]
+	},
+	{
+		"name": "Being Glue",
+		"url": "https://noidea.dog/glue",
+		"tags": ["software-engineering", "career", "teamwork"]
+	},
+	{
+		"name": "Customization vs. Configuration in Evolving Design Systems",
+		"url": "https://engineering.atspotify.com/2021/04/customization-vs-configuration-in-evolving-design-systems/",
+		"tags": ["software-engineering", "philosophy", "tech-debt"]
+	},
+	{
+		"name": "Write code that is easy to delete, not easy to extend.",
+		"url": "https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to",
+		"tags": ["software-engineering", "philosophy", "tech-debt"]
+	},
+	{
+		"name": "Repeat yourself, do more than one thing, and rewrite everything",
+		"url": "https://programmingisterrible.com/post/176657481103/repeat-yourself-do-more-than-one-thing-and",
+		"tags": ["software-engineering", "philosophy", "tech-debt"]
+	}
+]

--- a/packages/content/drafts/add-less-working-title.md
+++ b/packages/content/drafts/add-less-working-title.md
@@ -1,0 +1,17 @@
+---
+title: Thoughts on "Add Less"
+date: 2023-10-15
+tags:
+  - software
+  - architecture
+---
+
+Raw notes:
+
+- "websites start fast until you add things to make them slow" (Cassidy Williams)
+- the challenge is knowing when you need to do less and when you actually need "more"
+  - it's easy to be idealistic or dogmatic about how we build things without taking the
+    full context into account:
+    - what timeline are you working on, and is it a "hard" or "soft" timeline?
+    - will adding "more" help the bottom line? (aka the business needs customers)
+    - will you need "more" in the near- or far-term future?

--- a/packages/content/drafts/csrf-cheat-sheet.md
+++ b/packages/content/drafts/csrf-cheat-sheet.md
@@ -1,0 +1,20 @@
+---
+title: CSRF (Cheat Sheet)
+date: 2022-02-21
+tags:
+  - security
+  - http
+---
+
+- What is CSRF?
+  - CSRF stands for Cross Site Request Forgery
+  - This type of attack uses the cookies in a user's browser to make requests to an authenticated site that the user didn't intend to make.
+- Example / Diagram
+
+  - User is currently logged into site (for example their bank)
+  - The target site stores a _cookie_ in the user's browser to track authentication state. Whenever the user visits the target site and performs actions (for example, a money transfer), the browser sends that cookie along with the HTTP request. The _server_ then uses that cookie to determine that the user is authenticated.
+
+- How to protect against CSRF
+  - CSRF token (best)
+  - Same-Site cookies
+  - Disable CORS

--- a/packages/content/drafts/design-system-color-tokens.md
+++ b/packages/content/drafts/design-system-color-tokens.md
@@ -1,0 +1,31 @@
+---
+title: design system color tokens
+date: 2022-03-27
+tags:
+  - design-systems
+  - css
+---
+
+- common issues with design tokens
+  - going too abstract too soon
+  - tokens are _too_ constrained
+  - no guidance on how to use tokens
+  - thinking that components = tokens
+  - naming things too specific, or not clearly.
+- my working list of color system tokens
+  - `$base` - the base "canvas" of the application.
+  - `$base-muted` - this is from the same palette as `$base`, but used to de-emphasize an element's background. Depending on the theme, that could be lighter _or_ darker.
+  - `$base-strong` - this is from the same palette as `$base`, but used to emphasis an element's background. Depending on the theme, that could be lighter _or_ darker.
+  - `$contrast` - this is for content that's on top of `$base`. It should meet at least AA, ideally AAA contrast ratio.
+  - `$contrast-muted` - this is from the same palette as `$contrast` but is used to de-emphasize content. It should meet at least AA contrast ratio.
+  - `$contrast-strong` - this is from the same palette as `$contrast` but is used to emphasize content. It should meet at least AA contrast ratio.
+- system ideas
+  - per token, the following variants:
+    - `-muted`
+    - `-strong`
+    - `-contrast`
+    - `-contrast-muted`
+    - `-contrast-strong`
+  - per variant, the following interactive states:
+    - `-hover`
+    - `-active`

--- a/packages/content/drafts/engineering-challenges-spent-too-much-time-with.md
+++ b/packages/content/drafts/engineering-challenges-spent-too-much-time-with.md
@@ -1,0 +1,30 @@
+---
+title: Engineering challenges I've spent too much time with
+date: 2022-06-02
+tags:
+  - software-engineering
+---
+
+Over the last 10 years of my career there's certain engineering problems that I keep experiencing. Some are very very complex or seem simple on the surface with a giant iceberg of complexity underneath.
+
+I'm not trying to unpack all those problems here. Just going to keep a list of some of the ones I remember, along with a short summary of why that problem is a giant pain. The hope is that I can write some longer form articles about each one and why it's nasty as time goes on.
+
+## Filters
+
+Aka faceted search. Filters seem simple until you peek behind the curtain. Then you see a mess of complexity and tradeoffs. To make matters worse, nearly every app has them in varying levels of quality.
+
+There's too much to go into here, but at a high level:
+- State management in the frontend gets tricky, especially if you don't use the URL as the source of truth. Depending on the implementation + API latency, using the URL has its own challenges (avoiding page refreshes, input lag, etc).
+- The differences + relationships between "selections", "options", and a "facet/filter" (a group of selections + options) will undoubtedly trip you up at some point.
+- Efficiently aggregating results data into options can be a non-trivial database problem once you hit even a moderate scale. It also doesn't matter how many UI bells and whistles you have if the API serving results is slow.
+- Showing counts next to options is a standard UX for filters, but you have to decide when to refresh options + counts in response to selections. Every selection refreshes _something_: the challenge is figuring out what refreshes and how to keep the refresh logic sane.
+- You also have a number of challenging UX + UI problems: deciding how to display filters, responsiveness (especially if the filters are not in a drawer), virtualization, pagination-vs-infinite-scroll, refetching, caching, URL persistence, etc. Any one of these _individually_ is ~easy, putting them all together is what gets tricky.
+
+When it comes to filters, I have written short novellas about this at the last 3 companies I worked at. I've had the (mis-)fortune to build faceted search like 7-8 times in my career over 4-5 different roles. I'm hoping to write something more long-form here about them in the future to capture a more detailed view of all the problems I've seen.
+
+## Data tables
+
+## Forms
+
+## Server side rendering (SSR)
+

--- a/packages/content/drafts/infinite-scroll-and-accessibility.md
+++ b/packages/content/drafts/infinite-scroll-and-accessibility.md
@@ -1,0 +1,31 @@
+---
+title: Infinite scroll and accessibility
+date: 2022-02-03
+tags:
+  - accessibility
+  - html
+  -
+---
+
+## Outline
+
+- if you do infinite scroll, you better do it right for those using assistive tech
+
+  - if a feature only works for a portion of your users, it doesn't really work.
+
+- if you give a mouse a cookie...
+
+  - if you have enough data to require an infinite scroll, you probably should be
+    _windowing_ the data.
+  - windowing is really hard to do accessibly.
+
+- infinite scrolling + windowing aren't even necessarily a good UX at all.
+
+  - lose your place, oh whale.
+  - users maintain a mental model of where things are with pagination.
+  - infinite scrolling is good for data that actually is...infinite.
+
+- if accessibility is the goal, infinite scrolling is probably not the best choice.
+  - breaks the footer
+  - makes it impossible to jump to the "end" of the page
+  - harder for screen reader users to quickly find page content (especially content that hasn't been loaded yet!)

--- a/packages/content/drafts/myths-about-comments.md
+++ b/packages/content/drafts/myths-about-comments.md
@@ -1,0 +1,61 @@
+---
+title: debunking arguments against code comments
+tags:
+  - code-comments
+---
+
+Every month or two I end up seeing a post on LinkedIn or Twitter condemning code comments as "bad programming". And sometimes I just shrug it off and move on with my day.
+
+However, there's a lot of us out there that like code comments! They're a valuable tool for us to show empathy for our teammates that will maintain the code we write.
+
+A lot of arguments against comments come straight out of Clean Code, but these are the ones I've heard—both IRL and on the internet. As someone who likes comments, I think there's valid ways to address each of these arguments head-on.
+
+## "Don't write comments, put it in a variable instead"
+
+Ummm...I don't want to read variable names a mile long in camelCase. That makes my eyes bleed and my brain explode.
+
+Instead, we have a language construct for expressing complex and nuanced thoughts—sentences.
+
+Sure, redundant comments exist, and you should absolutely use good variables names. But variables aren't mutually exclusive with code comments.
+
+<!-- TODO: don't actually include the quote -->
+
+<!--
+> I don't remember the last time I wrote a comment in my code
+>
+> Most of the time we can get rid of comments by just extracting a method and providing a meaningful name.
+>
+> In programming, clarity and expressiveness are everything.
+>
+> As you can see in the image below, comments usually just add noise.
+-->
+
+## "Comments get out of date, code is the only source of truth"
+
+Comments don't get run by your runtime / compiler, so it's possible that they're misleading, out-of-date, or downright wrong.
+
+But I'll let you in on a little secret: it's not unique to comments. For example, variables and function names. Your runtime doesn't care if you name a variable `user.firstName` or `user.potato`.
+
+Codebases require maintenance, and comments are a part of the codebase. It's on you and your team to commit to maintaining them!
+
+## "Don't write comments, capture context in commit messages instead"
+
+First off, this only works if everyone on your team is diligent about their commit messages. In my career, I think I've worked in _one_ place where this was true.
+
+Second, commits have a higher impedance than code comments. You don't have to seek out comments, they're gonna be right next to the code they describe. You'll have to seek out the relevant commit after thinking to yourself "this code doesn't have all the context". If it's a long-lived codebase this could mean sifting through years of commits.
+
+Comments let you warn future maintainers, without forcing them to go find the relevant information themselves.
+
+## "Comments add too much noise, and code should be beautiful"
+
+The first part of this sentence is personal preference. And I'd argue that the second part isn't necessarily true—it all depends on how you view code.
+
+Some view code as something that should be a work of art on its own. And they're allowed to believe that.
+
+But for some of us (myself included) code is a means to an end. Making the code _beautiful_ is not the goal. Hence the phrase, ["make it work, make it right, make it fast"](https://wiki.c2.com/?MakeItWorkMakeItRightMakeItFast).
+
+Often "making it right" means swallowing our pride and using a comment because that's the clearest way to communicate why the code was written. The code that gets the job done won't always be crystal-clear to others (or future you)!
+
+---
+
+There's a whole host of arguments in _favor_ of writing comments, stay tuned for a future post!

--- a/packages/content/drafts/react-fc-vs-function-params.md
+++ b/packages/content/drafts/react-fc-vs-function-params.md
@@ -1,0 +1,114 @@
+---
+title: React.FC vs TypeScript function parameters
+date: 2022-02-03
+tags:
+  - typescript
+  - react
+  - formatting
+---
+
+My strong preference is to use regular TS function parameters to type React components, rather than the `React.FC` (or its longer alias, `React.FunctionComponent`) that comes packaged with `React`.
+
+At the end of the day, this is _mostly_ stylistic preference, but _even personal preferences have reasons behind them_. Those preferences may not be enough to quit a job or label a codebase as "terrible", but there's still benefits/tradeoffs to be considered.
+
+Here's a few reasons why I prefer TS function params to `React.FC`:
+
+## Implicit `children` prop
+
+`React.FC` implicitly adds some extra properties to the component — notably `props.children`
+
+```tsx
+type Props = {
+	className?: string;
+};
+
+// `children` is allowed here, no type error!
+const Example: React.FC<Props> = ({ className, children }) => {
+	return <div className={className}>{children}</div>;
+};
+```
+
+When you use regular TypeScript function parameters, `children` now results in a TS error
+
+```tsx
+type Props = {
+	className?: string;
+};
+
+// 🚨 TypeError: Property 'children' does not exist on type 'Props'.ts(2339)
+const Example = ({ className, children }: Props) => {
+	return <div className={className}>{children}</div>;
+};
+```
+
+This can be fixed by explicitly typing the `children` prop
+
+```tsx
+import { ReactNode } from 'react';
+type Props = {
+	className?: string;
+	children: ReactNode;
+};
+
+const Example = ({ className, children }: Props) => {
+	return <div className={className}>{children}</div>;
+};
+```
+
+`children` _is_ another prop that's part of your component's interface. So having to be explicit about when it is/isn't allowed is a good thing.
+
+## Shorter / less boilerplate
+
+Ditching `React.FC` also happens to be less code when declaring components.
+
+```tsx
+// #1. TS params
+const Comp1 = (props: Props) => <div />;
+// #2, TS params w/ explicit return type
+const Comp2 = (props: Props): JSX.Element => <div />;
+// #3. React.FC
+const Comp3: React.FC<Props> = (props) => <div />;
+```
+
+**Less characters typed doesn't always equal more readability!!** However, in this case, I think option #1 (TS params + return type inference) is a much lighter syntax.
+
+## Generic types
+
+Depending on the type of projects you work on, you may or may not use generics heavily. However, if you're working on abstractions like component libraries and general utility components you'll probably need to know a bit about TS generics.
+
+> If you're not familiar with TypeScript generics, check out [this overview](/typescript-generics) to learn more.
+
+With the simpler TS parameter syntax, you can more easily create generic components that _infer_ their types based on the props provided.
+
+```tsx
+type Props<T> = {
+	value: T;
+	onClick: (value: T) => void;
+};
+
+const Button = <T extends any>({ value, onClick }: Props<T>) => {};
+
+const Example = () => {
+	return (
+		<>
+			<Button
+				value="a"
+				// type of `value` here is "string"
+				onClick={(value) => console.log(value)}
+			/>
+			<Button
+				value={100}
+				// type of `value` here is "number"
+				onClick={(value) => console.log(value)}
+			/>
+		</>
+	);
+};
+```
+
+This is extremely powerful since you can provide rock-solid type declarations while still having dynamic, abstract components. And it's significantly more difficult (impossible?) with `React.FC`
+
+## Further reading
+
+- Create React App's [decision](https://github.com/facebook/create-react-app/pull/8177) to move away from `React.FC`
+- [Spotify ADR](https://backstage.io/docs/architecture-decisions/adrs-adr006) documenting moving away from `React.FC`

--- a/packages/content/drafts/simple-feature-flagging-with-environment-variables.md
+++ b/packages/content/drafts/simple-feature-flagging-with-environment-variables.md
@@ -1,0 +1,13 @@
+---
+title: Simple feature flagging with environment variables
+date: 2022-02-15
+tags:
+  - feature-flags
+  - software-engineering
+---
+
+- intro: what's a feature flag and why do we care?
+
+- segue: use the simplest possible flagging solution you can.
+
+- tutorial: how to do it with environment variables.

--- a/packages/content/drafts/ssr-is-not-more-complex.md
+++ b/packages/content/drafts/ssr-is-not-more-complex.md
@@ -1,0 +1,59 @@
+---
+title: Server-rendering your frontend app isn't "too complex"
+description: In fact, it might result in a simpler app overall.
+tags:
+  - http
+  - software-engineering
+---
+
+A common pushback I hear regarding server-rendering is that "we don't need the added complexity because {insert reason here}". And while I applaud the goal of reducing complexity, I'm not sure taking SSR off the table actually reduces complexity.
+
+In fact, your 100% client-rendered application might be _more_ complex than if you had server-rendered it. Here's why:
+
+## SSR isn't hard to set up
+
+These days most frontend frameworks will support some form of SSR with minimal config. In the React world alone you've got a few great options to pick from:
+
+- Remix
+- Next.js
+- Blitz.js
+- Redwood.js
+- ...and many more ✨
+
+## Some things are inherently easier on the server
+
+At a former job I remember one team having to do some significant rework to make user personalization happen on their client-rendered React app. This would have been much easier had they defaulted to a server-rendered model.
+
+Another example of something that's easier on the server is caching. On the server, you can easily cache requests in a data store like Redis or Memcached with minimal configuration. You can also send `Cache-Control` headers with your responses to help browsers cache data.
+
+In client-rendered React apps, it's usually an in-memory store (read: more JS running) caching API requests for the duration of the session. While this may _seem_ simple, it's a massive headache and a huge surface area for bugs.
+
+## Data flow is more direct on the server
+
+On the server you have a controlled environment where the "lifetime" of a request can be visualized in a fairly linear fashion:
+
+1. Data enters your server via the URL (route + params)
+2. Relevant data is fetched (or mutated) from the database or underlying microservices.
+3. HTML is rendered and sent to the browser
+4. Finally, JS sprinkles extra interactivity and pizzazz.
+
+The client is more flakey. You're bound to the whims of the user's network. Not to mention that now you have to think about concurrent API requests, race conditions, state management, and caching _in your frontend code_.
+
+You'll find that if you keep your client "thinner" (less state and more syncing to the server) data flow just becomes waaaaay easier to understand.
+
+## It's easier to squeeze perf out of your servers than your client
+
+Got a page that's rendering slowly in a server-rendered app?
+
+- Slow DB query (cache + optimize the query)
+- Slow microservice (cache + fix the service)
+- High memory load (scale horizontally / bump RAM while you work on lowering memory load)
+
+In short, you have the _agency_ to fix the cause behind the slowness quickly.
+
+You have no control over your users' devices — a fully client-rendered app could be slow for a myriad of reasons you don't control.
+
+- Internet speed (nothing you can do!)
+- Cheap device (low RAM) (nothing you can do!)
+- Request waterfalls (["spinnageddon"](https://twitter.com/ryanflorence/status/1186519682272022528))
+- Too much JS running (have to limit dependencies and do profiling work)

--- a/packages/content/drafts/strangler-fig-sveltekit.md
+++ b/packages/content/drafts/strangler-fig-sveltekit.md
@@ -1,0 +1,9 @@
+- need to set up endpoints to proxy the old app (in my case, Next.js required 2)
+
+  - `src/routes/[...path].ts` and `src/routes/_next/[...path].ts`
+
+- then, start migrating your pages 1 by 1!
+
+  - if your pages are prerendered (mine were), make sure to set `kit.prerender.crawl = false` in your `svelte.config.js` while you're migrating routes in the "middle" of your URL architecture. Otherwise you might find that the crawler will hit your proxy endpoints and store the HTML. Could depend on the hosting provider, but on Vercel this resulting in the HTML being _downloaded_ instead of _served_ in Chrome.
+
+- Note: my website currently doesn't have any data mutations. If you have data mutations strangler fig approach is gonna be a lot harder. But at a high level it's gonna be the same approach. Chances are you'll find that you want to store _less_ in frontend in-memomry state while migrating and sync things either to persistent browser memory or the server. That way you can easily hand things off between each app and migrate based on pages.

--- a/packages/content/drafts/web-platform-evolution.md
+++ b/packages/content/drafts/web-platform-evolution.md
@@ -1,0 +1,20 @@
+---
+title: Evolution of the web platform
+subtitle: Things that now exist just by "using the platform"
+tags:
+  - fundatmentals
+  - front-end
+  - software-engineering
+---
+
+- TL;DR
+
+  - Browsers have come a long way in the last 5 years, and now support many things natively that were previously only in "userland". As such, the web platform grows more and more powerful and we're able to "use the platform" more and more.
+
+- Resources
+  - [The balance has shifted away from SPAs](https://nolanlawson.com/2022/05/21/the-balance-has-shifted-away-from-spas/)
+  - [In defense of the modern web](https://dev.to/richharris/in-defense-of-the-modern-web-2nia)
+
+<!--
+Related: "use the platform" and adoption curves
+ -->

--- a/packages/content/intro.md
+++ b/packages/content/intro.md
@@ -1,0 +1,3 @@
+staff+ frontend engineer. i specialize in design systems, frontend architecture, and taking products from 0 → 1.
+
+currently @ [sublime.security](https://sublime.security).

--- a/packages/content/markdown-test.md
+++ b/packages/content/markdown-test.md
@@ -1,0 +1,186 @@
+# Heading Level 1
+
+## Heading Level 2
+
+This is a paragraph of text following the h2. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+### Heading Level 3
+
+This is a paragraph of text following the h3. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+#### Heading Level 4
+
+This is a paragraph of text following the h4. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+##### Heading Level 5
+
+This is a paragraph of text following the h5. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+###### Heading Level 6
+
+This is a paragraph of text following the h6. Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+---
+
+## Paragraphs
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+---
+
+## Text Styling
+
+Here is a paragraph that contains **a bit of bold text to show what that looks like**. Then for a little bit do regular to separate it from _the italics portion_. Lastly, [here's a link]() to nowhere.
+
+---
+
+## Lists
+
+For now the horizontal rhythm of these two list types are different because that's what feels right...rarely would you see a bulletted list immediately following a numbered list though 😎
+
+### Ordered
+
+1. Item
+1. Item
+1. Item
+1. Item
+   1. Inner
+   2. Inner
+1. Item
+1. Item
+1. Item
+1. Item
+
+### Unordered
+
+- Item
+  - Sublisted item
+  - Sublisted item
+  - Sublisted item
+- Item
+- Item
+- Item
+- Item
+
+---
+
+## BlockQuote
+
+In paragraphs for context.
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+> Here is the first line of the blockquote, a really long line that should wrap around on most screens
+>
+> And another line to see a little bigger
+>
+> Lastly, a third line
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+---
+
+## Code/Preformatted
+
+Here's a paragraph to show what `inline code blocks` look like...they won't be syntax highlighted, which is a good thing.
+
+```
+and this is a code block w/o highlighting...
+```
+
+### JavaScript
+
+```javascript
+// this has a comment above it.
+const greeting = (name) => `Hello ${name}`;
+
+console.log(greeting("world"));
+```
+
+### JSX
+
+```jsx
+const Button = (props) => (
+	<button
+		onClick={() => {
+			alert("hello");
+		}}
+	>
+		welcome!
+	</button>
+);
+```
+
+### HTML
+
+In paragraphs for context.
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit.
+
+```html
+<div class="sample">
+	<button class="button">click me!</button>
+</div>
+```
+
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit? Lorem ipsum dolor sit amet consectetur, adipisicing elit. Eveniet obcaecati ex eos at deserunt sed animi, ea beatae officiis impedit?
+
+### CSS
+
+```css
+:root {
+	--color-primary: #333;
+}
+
+.selector {
+	color: var(--color-primary);
+	background: papayawhip;
+	mask-image: url("https://localhost:3000/image.png");
+}
+```
+
+### Diff
+
+```diff
+nothing changed
++ added
+- deleted
+```
+
+## Callouts
+
+> [!NOTE]
+>
+> This is a note. You can use this to talk about quick asides and things that are somewhat tangential to the main point.
+>
+> You can make it as long as you want, even multiple paragraphs!
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!TIP]
+>
+> This is a tip. You can use it for basic helper tips that would clutter up the main
+> body of text
+>
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!IMPORTANT]
+>
+> **This is an important callout.** Use it to call attention to things that shouldn't be ignored or are...well...important.
+>
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!WARNING]
+>
+> This is a warning. Use it to highlight things that probably aren't correct anymore, or that you probably shouldn't do.
+>
+> This one also has a [link to google](https://google.com) and a `inline code`
+
+> [!CAUTION]
+>
+> This is a caution callout. Use this for things that are actually really bad and you want to call attention to it.
+>
+> This one also has a [link to google](https://google.com) and a `inline code`

--- a/packages/content/notes/building-an-infinite-scrolling-list-with-react/VirtualizedList.tsx
+++ b/packages/content/notes/building-an-infinite-scrolling-list-with-react/VirtualizedList.tsx
@@ -1,0 +1,230 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import debounce from "lodash/debounce";
+
+const SCROLL_DEBOUNCE_TIME = 200;
+
+interface GetPartialPageHeightArguments {
+	items: number;
+	itemsPerPage: number;
+	rowHeight: number;
+	columns: number;
+	offsetY: number;
+}
+
+/**
+ * Utility function to return the height of the final page. Within the list of
+ * items, the final page sometimes can be a partial page.
+ *
+ * This function figures out how many rows of items exist on the final page
+ * of the list and returns the calculated height of the page.
+ */
+const getPartialPageHeight = ({
+	items,
+	itemsPerPage,
+	rowHeight,
+	columns,
+	offsetY,
+}: GetPartialPageHeightArguments) => {
+	const numberOfPages = items / itemsPerPage;
+	const completePages = Math.floor(numberOfPages);
+
+	if (completePages === numberOfPages) {
+		const rows = itemsPerPage / columns;
+		return rows * rowHeight;
+	}
+
+	const lastPageStartIndex = completePages * itemsPerPage - 1;
+	const itemsOnLastPage = items - lastPageStartIndex - 1;
+	const lastPageRows = Math.ceil(itemsOnLastPage / columns);
+
+	return lastPageRows * rowHeight + offsetY;
+};
+
+/**
+ * Given an HTML element and the static height of each page, determine which
+ * page index the user is currently scrolled on.
+ *
+ * For the purposes of this function, the user is scrolled on a page once the page
+ * has intersected with the TOP of the window. This is an explicit trade-off for
+ * the sake of simplicity.
+ */
+const getCurrentScrollPage = (wrapper: HTMLElement, pageHeight: number) => {
+	const wrapperScrollOffset = wrapper.offsetTop;
+	const scrollPosition = window.scrollY;
+
+	const currentScrollPage = Math.floor(
+		(scrollPosition - wrapperScrollOffset) / pageHeight,
+	);
+
+	return Math.max(currentScrollPage, 0);
+};
+
+interface VirtualizedListPageProps {
+	children: ReactNode;
+	pagesBefore: number;
+	pageHeight: number;
+	lastPageHeight: number;
+	isLastPage?: boolean;
+	className?: string;
+	offsetY?: number;
+}
+
+/**
+ * A single "page" of items within the virtual list. Each page will be absolutely
+ * positioned based on its index and toggled based on the current scroll position.
+ */
+const VirtualizedListPage = ({
+	children,
+	pagesBefore,
+	pageHeight,
+	className,
+	isLastPage = false,
+	lastPageHeight,
+	offsetY = 0,
+}: VirtualizedListPageProps) => {
+	const height = isLastPage ? lastPageHeight : pageHeight;
+	return (
+		<div
+			className={className}
+			style={{
+				position: "absolute",
+				top: pagesBefore * pageHeight,
+				height: height + offsetY,
+				marginBottom: -1 * offsetY,
+				overflow: "hidden",
+				width: "100%",
+				boxSizing: "border-box",
+			}}
+		>
+			{children}
+		</div>
+	);
+};
+
+interface VirtualizedListProps {
+	renderPage: (index: number) => ReactNode;
+	items: number;
+	itemsPerPage: number;
+	/**
+	 * Number of columns per row in the page. This allows you to create grids with
+	 * your items and dynamically size the item widths. Defaults to `1`
+	 */
+	columns?: number;
+	rowHeight: number;
+	pageOffsetY?: number;
+}
+
+/**
+ * Renders a virtualized list.
+ *
+ * The primary reason for using a virtualized list is _performance_—rendering large
+ * lists of items throws a ton of elements into the DOM.
+ *
+ * While rendering 20-50 elements doesn't result in degraded performance, you might
+ * start to see dropped frames around 100-200 items, and the browser can potentially
+ * crash when you render 1,000+ items.
+ *
+ * This virtualized list using a technique called "windowing". For further reading
+ * on windowing techniques check out https://web.dev/virtualize-long-lists-react-window/.
+ */
+export const VirtualizedList = ({
+	renderPage,
+	columns = 1,
+	rowHeight,
+	items,
+	itemsPerPage,
+	pageOffsetY = 0,
+}: VirtualizedListProps) => {
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	const [currentPageIndex, setCurrentPageIndex] = useState(0);
+
+	const pages = Math.ceil(items / itemsPerPage);
+
+	const rowsPerPage = itemsPerPage / columns;
+	const pageHeight = rowsPerPage * rowHeight + pageOffsetY;
+	const lastPageStartIndex = pages - 1;
+
+	// Since the last page can be a partial page, determine its height separately
+	// from the rest.
+	const lastPageHeight = getPartialPageHeight({
+		items,
+		itemsPerPage,
+		columns,
+		rowHeight,
+		offsetY: pageOffsetY,
+	});
+
+	const pagesBefore = currentPageIndex;
+	const pagesAfter = lastPageStartIndex - currentPageIndex;
+
+	// NOTE: it's important to figure out the current page based on SCROLL POSITION
+	// rather than attempting to use an IntersectionObserver.
+	//
+	// Using an IntersectionObserver worked when scrolling slowly, but it didn't
+	// correctly toggle pages when scrolling quickly or when scrubbing the scroll bar.
+	// This is because you skip right past the entire IntersectionObserver and
+	// immediately scroll into empty space.
+	useEffect(() => {
+		const wrapper = wrapperRef.current;
+		if (!wrapper) return;
+
+		const handleScroll = debounce(() => {
+			const currentScrollPage = getCurrentScrollPage(wrapper, pageHeight);
+			setCurrentPageIndex(currentScrollPage);
+		}, SCROLL_DEBOUNCE_TIME);
+
+		window.addEventListener("scroll", handleScroll, { passive: false });
+
+		return () => {
+			window.removeEventListener("scroll", handleScroll);
+		};
+	}, [pageHeight]);
+
+	return (
+		<>
+			<div
+				ref={wrapperRef}
+				style={{
+					position: "relative",
+					overflow: "hidden",
+					marginBottom: pageOffsetY * -1,
+					paddingBottom: pageOffsetY,
+					height: lastPageStartIndex * pageHeight + lastPageHeight,
+				}}
+			>
+				{pagesBefore > 0 && (
+					<VirtualizedListPage
+						pageHeight={pageHeight}
+						lastPageHeight={lastPageHeight}
+						pagesBefore={pagesBefore - 1}
+						offsetY={pageOffsetY}
+					>
+						{renderPage(currentPageIndex - 1)}
+					</VirtualizedListPage>
+				)}
+
+				<VirtualizedListPage
+					pagesBefore={pagesBefore}
+					pageHeight={pageHeight}
+					isLastPage={currentPageIndex === lastPageStartIndex}
+					lastPageHeight={lastPageHeight}
+					offsetY={pageOffsetY}
+				>
+					{renderPage(currentPageIndex)}
+				</VirtualizedListPage>
+
+				{pagesAfter > 0 && (
+					<VirtualizedListPage
+						pageHeight={pageHeight}
+						isLastPage={currentPageIndex + 1 === lastPageStartIndex}
+						lastPageHeight={lastPageHeight}
+						pagesBefore={pagesBefore + 1}
+						offsetY={pageOffsetY}
+					>
+						{renderPage(currentPageIndex + 1)}
+					</VirtualizedListPage>
+				)}
+			</div>
+		</>
+	);
+};

--- a/packages/content/notes/building-an-infinite-scrolling-list-with-react/index.mdx
+++ b/packages/content/notes/building-an-infinite-scrolling-list-with-react/index.mdx
@@ -1,0 +1,215 @@
+---
+title: Building an infinite-scrolling list with React
+date: 2020-02-02T00:00:00.000Z
+tags:
+  - react
+  - typescript
+  - tutorials
+---
+
+## Intro
+
+### Do you _need_ an infinite list?
+
+### List virtualization and "windowing"
+
+### Why build it from scratch instead of {insert library here}?
+
+- Small, focused bundle size
+- Ability to customize and tweak to fit your needs.
+  - for example, if you want to allow the list to change the height of the window. (or to have it NOT change the height of the window).
+- Support for _pages_ of items and _grids_. This is a big one for the infinite lists I've built in the past. Most virtualization libraries supply the tools to do 1-dimensional lists fairly easily, or they allow virtualizing on both the x- and y-axis. So, doing a virtualized y-axis with a grid of items on the x-axis results in a lot of effort, equal to building the whole dang virtualized list yourself.
+- Deep knowledge of list virtualization. If you're building web apps, it's a good thing to know, and allows you to wow clients (or product managers) while still providing a good user experience.
+
+### Creating a good infinite scroll experience
+
+- ability to handle any number of items with smooth framerates while scrolling
+- ability to "load more" when the bottom of the list is reached
+- scroll scrubbing with lazy-loading
+- smaller bundle size than `react-window` (granted, it will also have a smaller feature set)
+- does not overflow or have weird spacing at the bottom of the list.
+- allows us to handle responsive sizing in _some_ fashion.
+
+## Let's build it!
+
+### Set up the shell of our list
+
+```tsx
+import React from 'react';
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+}
+
+export const VirtualizedList = ({ total, rowHeight }: VirtualizedListProps) => {
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: rowHeight * total
+			}}
+		></div>
+	);
+};
+```
+
+- inline styles for simplicity
+- light gray as "background" for now
+- we add 2 props to our list
+  - the total count of items we plan on rendering
+  - the height of each individual row. For now we're assuming that each row contains 1 item.
+- Finally, we use the count of total items and the height of each individual row to get the full height of our list.
+
+### Split our total count of items into "pages"
+
+```tsx
+import React from 'react';
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+	pageSize: number;
+}
+
+export const VirtualizedList = ({ total, rowHeight, pageSize }: VirtualizedListProps) => {
+	const pages = Math.ceil(total / pageSize);
+	const pageHeight = pageSize * rowHeight;
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: pageHeight * pages
+			}}
+		></div>
+	);
+};
+```
+
+- Add 1 more prop, now the amount of items in a "page".
+- Now, instead of calculating by the number of rows, we'll be calculating the total height by the number of "pages". Right now we only are rendering 1 item per row so the calculation will be fairly straightforward.
+
+### Fix the last page
+
+```tsx
+import React from 'react';
+
+type GetLastPageHeight = (args: { total: number; pageSize: number; rowHeight: number }) => number;
+
+const getLastPageHeight: GetLastPageHeight = ({ total, pageSize, rowHeight }) => {
+	const pages = total / pageSize;
+	const completePages = Math.floor(pages);
+
+	if (completePages === pages) {
+		return pageSize * rowHeight;
+	}
+
+	const lastPageStartIndex = completePages * pageSize - 1;
+	const itemsOnLastPage = total - lastPageStartIndex - 1;
+
+	return itemsOnLastPage * rowHeight;
+};
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+	pageSize: number;
+}
+
+export const VirtualizedList = ({ total, rowHeight, pageSize }: VirtualizedListProps) => {
+	const pages = Math.ceil(total / pageSize);
+	const pageHeight = pageSize * rowHeight;
+	const lastPageStartIndex = pages - 1;
+	const lastPageHeight = getLastPageHeight({
+		total,
+		rowHeight,
+		pageSize
+	});
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: pageHeight * lastPageStartIndex + lastPageHeight
+			}}
+		></div>
+	);
+};
+```
+
+- the list works great if the number of items evenly divides by the page size, but if it _doesn't_ we're left with some extra space at the bottom of the list. To get the height to be _exactly_ the number of items, we need to add some calculation for the final page of items.
+- we calculate how many complete pages exist, if that's the same as the total # of pages, then our calculation is more straightforward. Otherwise, we have to do a little extra math to figure out how many rows exist on the final page.
+
+### Add the ability to render a custom page of items
+
+```tsx
+import React, { Fragment, ReactNode } from 'react';
+
+type GetLastPageHeight = (args: { total: number; pageSize: number; rowHeight: number }) => number;
+
+const getLastPageHeight: GetLastPageHeight = ({ total, pageSize, rowHeight }) => {
+	const pages = total / pageSize;
+	const completePages = Math.floor(pages);
+
+	if (completePages === pages) {
+		return pageSize * rowHeight;
+	}
+
+	const lastPageStartIndex = completePages * pageSize - 1;
+	const itemsOnLastPage = total - lastPageStartIndex - 1;
+
+	return itemsOnLastPage * rowHeight;
+};
+
+export interface VirtualizedListProps {
+	total: number;
+	rowHeight: number;
+	pageSize: number;
+	renderPage: (index: number) => ReactNode;
+}
+
+export const VirtualizedList = ({
+	total,
+	rowHeight,
+	pageSize,
+	renderPage
+}: VirtualizedListProps) => {
+	const pages = Math.ceil(total / pageSize);
+	const pageHeight = pageSize * rowHeight;
+	const lastPageStartIndex = pages - 1;
+	const lastPageHeight = getLastPageHeight({
+		total,
+		rowHeight,
+		pageSize
+	});
+	return (
+		<div
+			style={{
+				background: '#eee',
+				height: pageHeight * lastPageStartIndex + lastPageHeight
+			}}
+		>
+			{Array.from({ length: pages }).map((_, index) => (
+				<div
+					key={index}
+					style={{
+						height: index === lastPageStartIndex ? lastPageHeight : pageHeight
+					}}
+				>
+					{renderPage(index)}
+				</div>
+			))}
+		</div>
+	);
+};
+```
+
+## Conclusion
+
+### Some next steps
+
+- Allow dynamically determining a page's size. In `react-window` this is called `VariableSizedList`
+
+### Resources
+
+- https://web.dev/virtualize-long-lists-react-window
+  /

--- a/packages/content/notes/code-comments.mdx
+++ b/packages/content/notes/code-comments.mdx
@@ -1,0 +1,56 @@
+---
+title: Code comments
+date: 2021-01-01T23:31:41.255Z
+tags:
+  - documentation
+  - tech-debt
+  - philosophy
+  - clean-code
+---
+
+## Thoughts in favor of comments
+
+- Commenting acknowledges that our concepts of what is "clean code" changes over time. Our preferences 20 years from now won't be the exact same as our preferences right now. Sure, _some_ will, but not all.
+- [A codebase is an organism](https://meltingasphalt.com/a-codebase-is-an-organism/), and comments acknowledge that this organism has a life of its own. Especially if you work on a high-velocity team with rapidly changing direction (startups), comments can be a lifesaver when you've written 10,000+ lines in the last 6 months.
+- There's a lot of bad comments out there. The solution isn't to ditch comments entirely, that's throwing the baby out with the bathwater.
+- Code comments are a lower _barrier to information_ than code. Sure, you can make code self-explanatory, but guess what's even more explanatory than code? Sentences.
+- Commenting isn't a science, it's an art. To write good comments, you have to become a _good writer_. There's no "One True Way", it's a little more convoluted and messy.
+- Code comments are an acknowledgement of human finiteness and imperfection. In a perfect world, we would write perfect code and have perfect knowledge of the code others wrote. We will never achieve this goal because we as humans are not perfect. Leaving comments in our code is a recognition that our code will never be perfect, but we can help the next person understand it a little better.
+
+## Anti-comment sentiment
+
+- Bob Martin says a comment is "an admission of failure to write good code". The idea is that instead of writing the comment, you should focus on rewriting the code to be clearer and more explanatory. This is _the line_ that most anti-comment sentiment stems from.
+- Another anti-comment sentiment is that the added context a comment provides can be put in a commit message or pull request. However, this fails to address to the barrier to information issue—finding a commit or PR requires some digging (especially if the file has a high churn rate).
+- Another objection to code comments and documentation is that unit tests can capture requirements in the same way a comment can. While unit tests do capture some acceptance criteria, I find that A) they serve a slightly different purpose from documentation, and B) they often get left out when the rubber meets the road.
+- Ironically, the chapter in "Clean Code" about comments _does not advocate for a no-comments-ever approach_. Rather, it discusses Martin's opinions about "good" comments and "bad" comments. And there's quite a bit in there about when comments are helpful.
+- Also ironically, a lot of anti-comment sentiment _written in books and on blogs_ is more moderate than anti-comment sentiment I've experienced in real life. I think one reason behind this is that anti-comment posts rely on flashy titles and blanket statements ("You shouldn't comment your code") and then backtrack into a more moderate position ("Don't use comments to paper over bad code"). But people read the polarizing blanket statement and walk away with the takeaway "Good code doesn't have comments, bad code does".
+
+## Some commenting guidelines
+
+- Commenting intent. The most valuable comments describe _why the code is the way that it is_. For example, is the code written to solve a specific edge case or bug? Or does it need to be a certain for performance or cross-platform compatability?
+- Use complete thoughts. For most comments, this means using complete sentences. However, I find myself also writing comments in an imperative voice—essentially prefixing my comment with an unwritten "This code..." before I describe the block of code.
+  - Why complete thoughts? Capturing a complete thought forces you to slow down and reflect on how to make the comment most valuable.
+  - Complete thoughts are easier for others to read. We're used to reading in complete sentences, most of us have been doing it since we were little kids.
+- If you do include a URL in your comment, add some extra context.
+  - This helps keep the comment skimmable and allows the reader to understand whether they need the additional information following the URL would provide.
+  - This helps with the shelf life of the comment as well. URLs can move or become invalid. Your company can cancel their JIRA account or move code from GitHub to GitLab. Capturing a tiny bit of context around the URL means that your comment might outlive the URL.
+- Take advantage of block comments. Most languages provide a block comment syntax that gets picked up by modern IDEs. This allows other engineers using your code to get a basic description of your code through intellisense.
+  - If you're in a dynamically typed language, block comments usually provide a syntax for documenting input/output shapes as well. For an example check out JSDoc's [`@param`](https://jsdoc.app/tags-param.html) and [`@returns`](https://jsdoc.app/tags-returns.html) tags.
+- ["Space shuttle style"](https://www.github.com/kubernetes/kubernetes/tree/ec2e767e59395376fa191d7c56a74f53936b7653/pkg%2Fcontroller%2Fvolume%2Fpersistentvolume%2Fpv_controller.go) (from the Kubernetes source code). This is probably the heaviest commenting style I've seen, but it draws inspiration from the [Apollo-11 source code](https://github.com/chrislgarry/Apollo-11). This style can be a useful tool for mission critical code where robust documentation is absolutely required.
+- When in doubt, err on the side of adding the comment. It's better to delete a redundant comment 6 months down the road than it is to wish you had written it down 6 months later. Over time your gut feeling of "should I write a comment?" will get more and more accurate.
+
+## Resources
+
+### Pro-comment sentiment
+
+- [Google's tech writing guides](https://developers.google.com/tech-writing/two/code-comments)
+- [“Good code documents itself” and other hilarious jokes you shouldn’t tell yourself](https://hackaday.com/2019/03/05/good-code-documents-itself-and-other-hilarious-jokes-you-shouldnt-tell-yourself/)
+- [Comment your f\*\*\*ing code](http://blog.codefx.org/techniques/documentation/comment-your-fucking-code/)
+- [Documentation is JSON for the Brain](https://www.ericholscher.com/blog/2017/feb/13/docs-are-json-for-the-brain)
+- ["My code is self-documenting"](https://www.ericholscher.com/blog/2017/jan/27/code-is-self-documenting/)
+
+### Anti-comment sentiment
+
+- [Clean code](https://www.oreilly.com/library/view/clean-code-a/9780136083238/), notably Chapter 4 which deals with comments.
+- [Do not comment bad code - rewrite it](https://www.ralin.io/blog/do-not-comment-bad-code-rewrite-it.html)
+- [Why You Shouldn't Comment (or Document) Code](https://visualstudiomagazine.com/articles/2013/06/01/roc-rocks.aspx)

--- a/packages/content/notes/finite-state-machines.mdx
+++ b/packages/content/notes/finite-state-machines.mdx
@@ -1,0 +1,14 @@
+---
+title: Finite State Machines
+date: 2021-01-29T00:00:00.000Z
+tags:
+  - programming
+---
+
+## What is a Finite State Machine, anyway?
+
+Finite state machines (FSM) have been around for a long time. Even though they're just now enjoying a surge of popularity, they're based on mathematic
+
+## Resources
+
+- https://xstate.js.org/docs/

--- a/packages/content/notes/friendly-vs-unfriendly-iframes.mdx
+++ b/packages/content/notes/friendly-vs-unfriendly-iframes.mdx
@@ -1,0 +1,30 @@
+---
+title: Friendly vs unfriendly iframes
+date: 2021-01-07T00:00:00.000Z
+tags:
+  - front-end
+  - html
+  - security
+---
+
+### Definition
+
+A **friendly `iframe`** has the same domain as its parent document.
+
+In contrast, an **unfriendly `iframe`** has a different `src` domain than its parent.
+
+### Differences
+
+The key difference between friendly and unfriendly `iframe`s boils down to the level of access afforded by the embedded document.
+
+In a friendly `iframe`, the embedded document has access to the parent's `window` object and can change things in the parent.
+
+However, an unfriendly `iframe` is bound by `same-origin policy` and does _not_ have access to the parent document's `window` object.
+
+### Why does it matter?
+
+The primary reason that an `iframe` is more restricted if it comes from another domain is _security_. That `iframe` comes from a domain that you "don't control". Even if you actually _do_ control the domain—there's no way of letting the browser know that.
+
+And if you _are_ iframing a site that you don't own, it's possible that the external site gets hacked, or introduces some invasive code. If they had access to your site's `window` object you've suddenly also been hacked! 😱
+
+This means that your "hostile" `iframe`s can only talk to their parent document via [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage). This builds security into the cross-site communication since the parent document has to explicitly listen for and interprest the message sent from the `iframe`.

--- a/packages/content/notes/nextjs-file-structure.mdx
+++ b/packages/content/notes/nextjs-file-structure.mdx
@@ -1,0 +1,66 @@
+---
+title: NextJS file structure
+date: 2021-02-04T00:00:00.000Z
+tags:
+  - nextjs
+  - react
+  - architecture
+  - file-structure
+---
+
+## Guiding principles behind a file structure
+
+- **Flexibility.** A good file structure allows for evolution—it makes it easy to delete code and move files around.
+- **Colocation.** We want to keep relevant code together to minimize context switching and digging through the filesystem.
+- **Simplicity.** We don't want some elaborate file structure that takes 20 minutes to explain. Ideally we can describe the core principles of a structure in a couple sentances.
+
+## Use a flat file structure for small apps
+
+For small NextJS apps I like to keep my file structure flat.
+
+```
+my-project
+└─ api
+│     └─  login.ts
+│     └─  posts.ts
+└─ components
+│     └─  __tests__
+│     │     └─  Button.test.tsx
+│     │     └─  Card.test.tsx
+│     └─  Button.tsx
+│     └─  Card.tsx
+└─ lib
+│     └─  __tests__
+│     │     └─  handleUserInput.test.ts
+│     │     └─  useDebounce.test.tsx
+│     └─  handleUserInput.ts
+│     └─  useDebounce.ts
+│     └─  fetchPosts.ts
+└─ integration
+│     └─  index.test.ts
+│     └─  about.test.ts
+│     └─  sign-up.test.ts
+└─ test-utils
+│     └─  setupTests.ts
+│     └─  renderPage.ts
+└─ pages
+│     └─  index.tsx
+│     └─  about.tsx
+│     └─  sign-up.tsx
+└─ styles
+│     └─  reset.css
+
+```
+
+## Group by feature for large apps
+
+```
+my-project
+└─ features
+│     └─  blog
+│     │     └─  api
+│     │     └─  lib
+│     │     └─  integration
+│     │     └─  components
+│     │     └─  pages
+```

--- a/packages/content/notes/php-cheatsheet.mdx
+++ b/packages/content/notes/php-cheatsheet.mdx
@@ -1,0 +1,62 @@
+---
+title: PHP cheatsheet
+date: 2021-01-14T00:00:00.000Z
+---
+
+## Declaring variables
+
+```php
+$variable = 'value';
+```
+
+## Object operator (`->`)
+
+```php
+// Create an object
+$obj = new stdClass();
+
+// Set a property on an object
+$obj->prop = 'test';
+
+// Get a property on an object
+$prop = $obj->prop;
+print( $prop ); // test
+
+// Call a method on an object
+$obj->method();
+```
+
+## "Arrays"
+
+PHP arrays are _very_ different than JavaScript arrays. They're more similar to JavaScript _objects_, even though they use the square bracket syntax.
+
+```php
+$arr = [
+  'key1' => 'val', // the => assigns the value to the key
+  'key2' => 'val2'
+];
+```
+
+The equivalent JS code would be something like this:
+
+```js
+const arr = {
+	key1: 'val',
+	key2: 'val2'
+};
+```
+
+In addition, you _can_ use a PHP `array` as a sorted, unkeyed list (similar to a JS array), in that case you would use the array syntax _without_ the key syntax
+
+```php
+$arr = [
+  'val', // key is 0
+  'val2' // key is 1
+];
+```
+
+To access an array value, you can use the square brackets along with the key name:
+
+```php
+$arr['key'];
+```

--- a/packages/content/notes/programming-benchmarks.mdx
+++ b/packages/content/notes/programming-benchmarks.mdx
@@ -1,0 +1,60 @@
+---
+title: Programming Benchmarks
+date: 2021-01-01T23:31:41.255Z
+---
+
+## Why is a programming benchmark useful?
+
+> ⚠️ WIP
+
+- Lets you compare methods of solving the same problem.
+- Allows you to focus on the _mechanics_ of a language or framework.
+- Allows you to work within a _domain_ that you're already familiar with.
+
+## Marks of a great programming benchmark
+
+> ⚠️ TBD
+
+## Existing programming benchmarks
+
+### [TodoMVC](http://todomvc.com/)
+
+This is perhaps the most well-known full-stack benchmark out there. TodoMVC is great if you're trying to get familiar with a language or framework. However, it should be viewed as an "intro" to a framework rather than a comprehensive benchmark capable of highlighting strengths and weaknesses.
+
+### [Hacker News PWA](https://hnpwa.com/)
+
+Hacker News PWA is another common benchmark you'll see in the wild. It markets itself as a "spiritual successor to TodoMVC"—it's more complex and focuses on more modern technologies, especially progressive web apps.
+
+### [7GUIs](https://eugenkiss.github.io/7guis/)
+
+7GUIs is set of 7 exercises ranging from trivial (counter) to complex (spreadsheet). After you've done all 7 you should have a good feel for a language or framework. The only caveat (for me) is that it doesn't address some modern development challenges like data fetching (which has been [acknowledged by its creator](https://hackernoon.com/towards-a-better-gui-programming-benchmark-397aca3542b8), Eugen Kiss)
+
+## My own programming benchmarks
+
+Here's a few benchmarks I've used in the past when I'm exploring a framework or language.
+
+### Simple counter
+
+Usually the first thing I build after learning the basic syntax of a framework is a simple counter.
+
+These are the "acceptance criteria" for the counter benchmark:
+
+- The counter should display its current count and begin at 0.
+- The counter has three controls: `+`, `-`, and `Reset`.
+  - `+` adds 1 to the counter.
+  - `-` removes 1 from the counter. If the counter is already at `0`, `-` should do nothing (or be disabled).
+  - `Reset` sets the counter to `0`.
+
+What I like about the counter as a first benchmark is it is _very limited in scope_. This makes it great for a first foray into a new language or framework. This allows you to grow familiar with the basic syntax, simple state management, and simple rendering.
+
+### GitHub Repository Search
+
+> ⚠️ TBD
+
+### Login form
+
+> ⚠️ TBD
+
+## Some ideas for future benchmarks
+
+- Beer API filter + search (https://api.punkapi.com/v2/)

--- a/packages/content/notes/python-syntax.mdx
+++ b/packages/content/notes/python-syntax.mdx
@@ -1,0 +1,452 @@
+---
+title: Python syntax
+date: 2021-01-02T00:00:00.000Z
+tags:
+  - programming-languages
+  - python
+  - programming
+---
+
+## Bookmark
+
+https://docs.python.org/3.8/tutorial/modules.html
+
+## Version
+
+Python 3.8.x
+
+## Arithmetic
+
+- Division `(x / y)` _always returns a float_.
+- If you want to divide and round down (floor division), you can use the `//` division operator.
+- `%` returns the remainder (modulo)
+- `**` does an exponent
+- Mixing a floating point and integer in operations results in the a floating point conversion.
+
+## Variables
+
+- No "variable" operator, you can just use `=` to assign a variable: `name = value`
+
+## Strings
+
+- Single or double quotes
+- `\` as escape character
+- **raw string**: add `r` before the first quote to not escape `\` characters. `r'something with a \'
+- **multiline strings**: triple quotes `"""..."""`. Trailing backlash adds a new line to the string.
+- `+` concatenates strings. Strings next to each other are automagically concatenated (`'Py' 'thon'`). This doesn't work with variables, you'd have to use `+`
+- `*` repeats a string
+
+- Strings are _immutable_—instead of changing one, create a new one
+- String length with the built-in `len()` function
+
+## Lists
+
+- Designated with _square brackets_ (`nums = [1, 2, 3, 4, 5]`)
+- Indexing with square brackets (`nums[0]` returns `1`)
+- Slicing creates a new list from a subset (`nums[1:3]` returns `[2, 3, 4]`)
+- Slicing a complete _shallow copy_ of a list (`nums[:]`)
+- List concatenation with `+` operator (`[1, 2] + [3, 4, 5]` returns `[1, 2, 3, 4, 5]`)
+- Lists are _mutable_ so you can reassign values with the index access
+
+## Control Flow
+
+### `if` / `elif` / `else`
+
+- syntax is `if condition:` and then starts a new indentation block.
+- `elif` is a convenience keyword, essentially `else` + `if` to avoid an extra indentation block.
+
+### `for` loops
+
+- Notable difference to JS (C-style languages) is that the `for` _doesn't_ let you define the exit condition.
+- Rather, it only iterates over items in a sequence (like a list)
+
+```py
+planets = ['mercury', 'venus', 'earth', 'mars']
+
+for l in letters:
+  print(l, len(l))
+```
+
+- Instead of mutating collections inside an iteration, it's usually recommended to create a copy or a new collection.
+
+### `range`
+
+Gives you a range of numbers of length `n`
+
+```py
+# If only 1 argument, specifies the _length_
+range(5) # 0, 1, 2, 3, 4
+
+# If there's 2 arguments, 1st is start and 2nd is end (non-inclusive)
+range(5, 10) # 5, 6, 7, 8, 9
+
+# Third argument specifies the increment size
+range(0, 10, 3) # 0, 3, 6, 9
+```
+
+- Note that `range` _isn't a list_, even though it often behaves as such. It's an _iterable object_.
+
+### `break` & `continue` statements, `else` clauses in loops
+
+- `break` works exactly the same as JS—it breaks out of the current (innermost) loop.
+- A loop can have an `else` clause after the `for`. This run _if the loop terminates without executing anything in its body._
+- Note that `else` will _not_ execute if the loop ends by being terminated with a `break` statement.
+
+```py
+for n in range(2, 10):
+    for x in range(2, n):
+        # Since this code is protected with an `if` it will only execute
+        # if the number has a multiple.
+        if n % x == 0:
+          print(n, 'equals', x, '*', n // x)
+          break
+    else:
+        # This code only executes if we go thru the entire loop without matching
+        # the `if` condition.
+        print(n, 'is a prime number')
+```
+
+- `continue` statement also behaves the same as JS due to its common ancestry from C. It will break out of the current iteration of the loop and start the next iteration.
+
+### `pass` statements
+
+This literally _does nothing_.
+
+_Note: seems similar to JS's `void` keyword. I wonder what the similarity / differences between the two would be._
+
+This is commonly used as a placeholder while you're mocking out code. You can set it up and think at a higher, more abstract level.
+
+### Defining functions
+
+- The `def` keyword allows you create a new function.
+
+```py
+def fibonnacci(n):
+  """This is the docstring syntax, on the first line."""
+  a, b = 0, 1
+  while a < n:
+      print(a, end=' ')
+      a, b = b, a+b
+  print()
+
+fibonnacci(100)
+```
+
+A couple things of note about functions:
+
+- The first line of the function can be a string literal (triple `"`). This is the doc comment syntax when present.
+- Any variables declared within the function body will be _scoped to the function and override outside variables with the same names_.
+- Functions don't _have_ to return a value, by default they will return a built-in value of `None`
+- Returning a value from a function can be done with the `return` keyword.
+
+Arguments can be defined in a few syntaxes:
+
+- Default arguments. `def add(a, b=2):`.
+- Keyword arguments. Arguments can be called with either the _name_ or just with a positional valuable.
+- Catch-all arguments. `*argumentName` catches all unnamed arguments past the formally declared arguments as a list. `**argumentName` catches all the named arguments as an object.
+
+Functions can also define _how_ callers can use them, restricting certain arguments to keyword-based or position-based. Both can be used in the same function.
+
+```py
+def f(pos1, pos2, /, pos_or_keyword, *, keyword1, keyword2):
+    pass
+```
+
+Guidance from docs:
+
+```
+- Use positional-only if you want the name of the parameters to not be available to the user. This is useful when parameter names have no real meaning, if you want to enforce the order of the arguments when the function is called or if you need to take some positional parameters and arbitrary keywords.
+
+- Use keyword-only when names have meaning and the function definition is more understandable by being explicit with names or you want to prevent users relying on the position of the argument being passed.
+
+- For an API, use positional-only to prevent breaking API changes if the parameter’s name is modified in the future.
+```
+
+### Lambda expressions
+
+```py
+lambda arg: body
+```
+
+```py
+lambda a, b: a + b
+```
+
+### Function annotations (static typing)
+
+These serve as _optional type hints_ to function paramaters and are addable with the following syntax:
+
+```py
+def add(a: int, b: int) -> int:
+  return a + b
+```
+
+Types can be aliased the same way as variables, but using `TypeVar`:
+
+```py
+from typing import TypeVar
+
+T = TypeVar('T', str)
+```
+
+## Style guides
+
+Looks like [PEP 8](https://www.python.org/dev/peps/pep-0008/) is the more common and "blessed" style guide.
+
+Some notable pieces:
+
+- 4-space indentation.
+- 79-character width.
+- Use docstrings
+- Comments should be on new lines
+- Use spaces around operators and after commas, but not directly inside brackets (i.e. `(a + b)`)
+- `PascalCase` for classes and `lower_case_snake_case` for functions & methods. `self` should always be the name of the first method argument.
+
+## Data structures
+
+### List methods
+
+- `list.append(x)`: adds an item to the end of a list.
+- `list.extend(iterable)`: pushes all of the items in the iterable to the end of the list.
+- `list.insert(i, x)`: inserts `x` at the given position `i`
+- `list.remove(x)`: removes the first item in the list that matches value `x`
+- `list.pop([i])`: removes the item at index `i` in the list. `i` defaults to the last item in the list.
+- `list.clear()`: removes all items from the list
+- `list.index([i[, start[, end]])`: returns the index of the first item in the list matching `x`. Throws `ValueError` if no match is found. `start` and `end` can be used to limit the indexes of the list that are searched.
+- `list.count(x)`: returns the number of items in the list matching value `x`
+- `list.sort(*, key=None, reverse=False)`: sorts the list items in place.
+- `list.reverse()`: reverse the order of the list in place.
+- `list.copy()`: creates a shallow copy of the list.
+
+### Using lists as stacks
+
+The built-in list methods give us all of the primitives needed to use them as a _stack_ data structure.
+
+> _As a reminder, a stack is a data structure with "last in, first out" handling of items._
+
+You can add an item to the "top" of the stack using `append` (even though it's the "end" of the list). Then, you can use `pop` to get the last item.
+
+```py
+stack = [1, 2]
+
+stack.append(3)
+stack.append(4)
+stack.append(5)
+
+print(stack)
+# [1, 2, 3, 4, 5]
+
+stack.pop() # 5
+stack.pop() # 4
+stack.pop() # 3
+```
+
+### Using lists as queues
+
+> _As a reminder, a **queue** deals with items in the order of "first-in, first-out"._
+
+You _can_ also use lists as queues, but they're not going to be _as_ efficient. The reason is that operations to the beginning of the list aren't as "fast" since the items in the list have to be re-indexed.
+
+If you absolutely need a queue, then it's probably better to build one or use a prebuilt package (`dequeue`).
+
+### List comprehensions
+
+A _list comprehension_ is essentially a set of square brackets (the list) containing an expression, followed by a `for` clause. Finally, the `for` clause can optionally be followed by `for` or `if` clauses, which can add additional context.
+
+Here's a simple list comprehension to generate a list of squares from 0 - 9
+
+```py
+squares = [x ** 2 for x in range(10)]
+```
+
+However, list comprehensions can be significantly more complex:
+
+```py
+[(x, y) for x in [1, 2, 3] for y in [3, 1, 4] if x != y]
+
+# The equivalent code with for-loops
+
+l = []
+
+for x in [1, 2, 3]:
+    for y in [3, 1, 4]:
+        if x != y:
+            l.append((x, y))
+
+l # [(1, 3), (2, 1), (3, 4)]
+```
+
+### Nested list comprehensions
+
+The first portion of the list comprehension (the expression) can also be _another_ list comprehension.
+
+> **Side-note**: _I imagine this could get a little wonky to read if taken too far. But it's pretty cool how concise this can make code._
+
+```py
+matrix = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 10, 11, 12]
+]
+
+# Transpose / flip the rows and columns.
+transposed = [[row[i] for row in matrix] for i in range(4)]
+
+# This is equivalent to the following code.
+def transpose():
+    transposed = []
+
+    for i in range(4):
+        transposed.append([row[i] for row in matrix])
+
+    return transposed
+
+# If we completely undo the inner list comp we end up with this:
+def transpose():
+    transposed = []
+
+    for i in range(4):
+        transposed_row = []
+
+        for row in matrix:
+            transposed_row.append(row[i])
+
+        transposed.append(transposed_row)
+
+    return transposed
+```
+
+### The `del` statement
+
+`del` allows you to remove an item from a list _using its index_ instead of its value.
+
+```py
+a = [1, 2, 3, 4, 5, 6, 7]
+
+del a[1]
+print(a) # [1, 3, 4, 5, 6, 7]
+
+# del can also take a slice of the list
+del a[2:4]
+print(a) # [1, 2, 6, 7]
+
+del a[:]
+print(a) # []
+```
+
+### Tuples & Sequences
+
+```py
+# Tuples can be assigned with or without parentheses
+tuple = 1, 2, 3
+tuple = (1, 2, 3)
+
+# The values of a tuple can be "unpacked", similar to destructuring in JS.
+# The number of variables on the right must exactly match the number of items
+# in the tuple.
+first, second, third = tuple
+```
+
+Some notes on tuples:
+
+- tuples themselves are _immutable_. However, they can contain mutable objects.
+
+### Sets
+
+A _set_ is an unordered collection of values where each value is guaranteed to appear only 1x within the set.
+
+Sets can be created in the following ways:
+
+```py
+s = {"mercury", "venus", "earth", "mars", "jupiter"}
+s = set(["mercury", "venus", "earth", "mars", "jupiter"])
+```
+
+Sets allow some easy methods for testing existence of a value as well as eliminating duplicate values:
+
+```py
+arr_1 = [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1]
+arr_2 = [1, 2, 3, 10]
+
+a = set(arr_1)
+b = set(arr_2)
+
+# test for existence of a value
+5 in a
+
+# unique values in arr_1
+a
+
+# values in arr_1 but not in arr_2 (difference)
+a - b
+
+# combination of all values in a OR b OR both (union)
+a | b
+
+# only the values in BOTH a AND b (intersection)
+a & b
+
+# only the values in a OR b, but NOT both (symmetrical)
+a ^ b
+```
+
+Set comprehensions can also be created, similar to list comprehensions
+
+```py
+a = {x for x in 'abracadabra' if x not in 'abc'} # {'r', 'd'}
+```
+
+### Dictionaries
+
+This is a key-value store, keys can only be immutable types (strings and numbers). Tuples can be a key as long as _they_ do not contain any mutable types as well.
+
+```py
+pets = {'moses': 1, 'bubbles': 2, 'sadie': 3}
+
+pets['moses'] # 1
+
+del pets['sadie']
+```
+
+You can also build a dictionary from key-value tuples using `dict`, dict comprehensions, or simple named arguments (for simple keys):
+
+```py
+# tuples
+dict([('moses', 1), ('bubbles', 2), ('sadie', 3)])
+
+# dict comprehension
+{x: x**2 for x in (2, 4, 6)} # { 2: 4, 4: 16, 6: 36 }
+
+# simple named args
+dict(moses=1, bubbles=2, sadie=3)
+```
+
+### Looping techniques
+
+You can loop thru an object and get the key _and_ value simultaneously using the `.items()` method.
+
+```py
+pets = {'moses': 1, 'bubbles': 2, 'sadie': 3}
+
+for name, pet_id in pets.items():
+    print(name, ': ', pet_id)
+```
+
+In a sequence you can get the index _and_ value simultaneously using the built-in `enumerate` function.
+
+```py
+nums = [1, 2, 3, 4, 5, 6]
+
+for i, v in enumerate(nums):
+    print(i, ': ', v)
+
+# 0: 1
+# 1: 2
+# 2: 3
+# ...
+```
+
+### More on conditional operators
+
+- You can use the keywords `and` & `or` to chain conditionals together. Expressions are evaluated left-to-right, and evaluation stops as soon as the condition is determined (i.e. if the first one is false in `A and B and C`, `B` and `C` won't be evaluated).
+- If you do assignment _inside_ the condition you have to use `:=` instead of `=`.

--- a/packages/content/notes/redis-cheatsheet.mdx
+++ b/packages/content/notes/redis-cheatsheet.mdx
@@ -1,0 +1,31 @@
+---
+title: Redis cheatsheet
+date: 2021-01-27T00:00:00.000Z
+---
+
+## Installation
+
+If you're on a Mac (usually the case for me), you can install Redis via Homebrew:
+
+```bash
+brew update
+brew install redis
+```
+
+## Starting the server
+
+You can start the server in a background process with `brew services`:
+
+```bash
+brew services start redis
+```
+
+```bash
+brew services stop redis
+```
+
+Alternatively, if you don't want to run Redis in the background, you can use the `redis-server` to start Redis:
+
+```bash
+redis-server /usr/local/etc/redis.conf
+```

--- a/packages/content/notes/soap.mdx
+++ b/packages/content/notes/soap.mdx
@@ -1,0 +1,11 @@
+---
+title: SOAP APIs
+date: 2021-01-07T00:00:00.000Z
+tags:
+  - back-end
+  - http
+---
+
+## What is SOAP?
+
+At a high-level, SOAP (Simple Object Access Protocol) is a _protocol_ for accessing resources on the internet. Whereas REST—an HTTP protocol more commonly used today—deals with JSON requests and responses, SOAP relies on **XML** for defining request and response objects.

--- a/packages/content/notes/when-to-build-from-scratch-vs-using-a-library.mdx
+++ b/packages/content/notes/when-to-build-from-scratch-vs-using-a-library.mdx
@@ -1,0 +1,7 @@
+---
+title: When to build from scratch versus using a library
+date: 2020-02-02T00:00:00.000Z
+tags:
+  - programming
+  - philosophy
+---

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "@benjamminj/content",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module"
+}

--- a/packages/content/writing/2022-year-in-review.md
+++ b/packages/content/writing/2022-year-in-review.md
@@ -1,0 +1,49 @@
+---
+title: '2022 year in review'
+date: 2023-01-03
+tags:
+  - career
+  - updates
+---
+
+Modern life is so fast-paced. Years can easily soar past if we’re not careful, and this time between Christmas and New Years is a perfect opportunity to reflect on all the significant things that have happened over the past year.
+
+Here’s some of my reflections on what happened in 2022.
+
+# 👶🏻 Baby
+
+In March my wife and I welcomed our son to our family. Becoming a dad and watching this little boy grow up (so fast!) has been awesome.
+
+I’m grateful to Panther Labs for offering a generous parental leave that allowed me to spend the first few months of my son’s life bonding with him and my wife.
+
+It’s remarkable how much my son has grown throughout this year. We’ve gotten to watch him go from a little newborn to crawling and stumbling around the house. I’m so excited to see him grow up even more in 2023.
+
+# ⬆️ Promotion to principal engineer
+
+Sometime in May (while I was out on parental leave) I got a call from my employer. Turns out I had gotten promoted during the regular performance review cycle!
+
+Operating as a principal engineer at Panther taught me a ton—notably about having influence without institutional authority, setting technical direction, mentorship, and technical leadership.
+
+# 🏠 Purchasing a house
+
+In early August my wife and I closed on our first house! It’s been fun doing some light home improvement projects, settling in, and not planning another stressful move for a long while.
+
+# 🌱 Being a (temporary) manager
+
+In late October I stepped in as an interim manager at Panther while we backfilled an open manager role on my team. Being an interim manager required me to change my entire job description overnight—I wasn’t 50% individual contributor (IC) and 50% manager, I was 100% manager for a limited amount of time.
+
+I enjoyed some aspects of the job and disliked others. Some notable highlights were tightly collaborating with my PM & designer, and getting to know my teammates much better.
+
+I was told that I did an ok job and that I could probably continue down the management path if I wanted to. However, my stint in management was also a confirmation of my desire to stay on the IC track for the foreseeable future.
+
+# 💼 New job
+
+Just a few weeks ago, I started a new job at [Sublime Security](https://sublimesecurity.com/)! I’m back as an IC, working on their frontend experiences. I’m terribly excited about this opportunity and looking forward to diving deep into their frontend stack as I enter 2023.
+
+# 🗓️ What’s next?
+
+2022 was a huge year, full of massive milestones. I don’t know what 2023 will hold, and I try not to forecast too far ahead!
+
+That said, I’m planning on watching my son grow up even more (I love working from home), settling more into our house, and building some amazing stuff at Sublime.
+
+Here’s to 2022 🥂

--- a/packages/content/writing/5-myths-about-the-post-bootcamp-job-search.md
+++ b/packages/content/writing/5-myths-about-the-post-bootcamp-job-search.md
@@ -1,0 +1,58 @@
+---
+title: 5 Myths About The Post-Bootcamp Job Search
+description: Here’s 5 common misconceptions that could be holding you back from your first development job.
+date: 2017-08-14
+image:
+  url: 'blog-img-man-at-desk.jpg'
+  alt: Man working at desk, taking notes
+tags:
+  - career
+---
+
+These days it seems like everybody is trying to break into tech. I was just there 2 months ago: and if you had told me that my job search would only be 6 weeks, I would have just written you off as wildly optimistic.
+
+I’ve also seen a lot of other bootcampers struggle to find their first job, largely because they have huge misconceptions about the development landscape. As a result it takes them months to find something or they settle for way less than market rate. I used to believe a lot of these myths, and I was fortunate enough to have someone snap me out of it right as I started my job search.
+
+Without further ado, here’s 5 common misconceptions that could be holding you back from your first development job.
+
+## Myth #1: You can’t provide real value if you are at an entry level.
+
+You have the capacity to provide real, monetary value to companies, even with 3–6 months of experience. The fact is that you are paid to solve problems and provide business value to your employer, not just to learn or gain experience. And companies like to hire people that can solve their problems.
+
+If you focus on how you can provide value to a company instead of what you can get out of it you will portray yourself as a more savvy & attractive candidate than someone who doesn’t. Show that you’re capable of seeing real problems a business may be facing and make sure you propose solutions as you go through the interview process.
+
+## Myth #2: Now that you’re done with bootcamp, you can stop learning to code and focus on finding a job.
+
+This couldn’t be farther from the truth. In fact, I’d argue that this is one of the biggest mistakes that I saw a lot of my fellow bootcamp grads make.
+
+If you haven’t written a line of code since you graduated, get up and make something today. And I don’t mean follow a tutorial or solve a couple CodeWars kata. Of course, when you finish your bootcamp you’ll end up spending a little more time doing non-coding things, but don’t forget to make a project here or there — it keeps your chops up, shows that you have passion and self-motivation, and allows you to feed that passion that first got you into programming.
+
+The tech world moves at a breakneck pace, and you want to be up-to-date. Being able to talk shop about the major frameworks/developments in your language of choice shows that you have passion, self-motivation, and the intellectual capacity to understand their nuances.
+
+For example, if you were a frontend dev (or targeting frontend positions), you would want to know about the differences between React/Vue/Angular or a bit about ES5 vs ES2015+.
+
+## Myth #3: The projects you did in dev bootcamp will speak for themselves.
+
+This ties into the last point.
+
+You probably made 1–4 “original” projects while you were in dev bootcamp. You put the code up on GitHub where everyone can see what an amazing job you did. That’s awesome. You’re off to great start!
+
+The thing is, bootcamps have varying degrees of hand-holding with their projects. Maybe you worked in a group with other fellow students. Maybe you worked alone, but you had a mentor or TA help you when you got stuck. Maybe you did most of the work yourself with minimal help. The point is, you have to continue to work on stuff after you graduate.
+
+You could do anything! Everyone has a friend or relative that’s looking for either a website or needs a website facelift. Tons of nonprofits/small businesses would be willing to take chances on young developers since they can’t afford the experienced ones. Open Source projects are always in desperate need of contributors, and there’s entire sites devoted to making it easy for newbies to start contributing.
+
+If all those fail (which I find hard to believe), build another personal project. Redesign your portfolio. Make that open source package you thought would be fun. The more you have to show your competence, the better— especially when you don’t have years of experience in your favor.
+
+## Myth #4: You learned all of the fundamentals in your programming language of choice.
+
+Whatever language(s) that you learned are extremely nuanced. Chances are it’s been around for a while, and the community around that language has its share of best practices/debates.
+
+Make it your goal to learn some of the nuances/gotchas of whatever language you plan to be interviewing in—it will really set you apart from other bootcampers that only learned what their curriculum taught.
+
+Of course it’s also worth noting that not all bootcamps are equal in this regard. Some really dive into language fundamentals while others gloss over. The responsibility becoming a master of your craft is yours alone.
+
+## Myth #5: You just need to get your job, then everything will settle down.
+
+Have a bigger vision than your first developer job. Keep building side projects, learning new technologies, and networking your butt off. If you ever feel like you’re plateauing, find a way to move forward or find someone to help you.
+
+This is your career we’re talking about, not just your first developer job. Take ownership of your personal brand and your professional development and continue to build both of them while you work at your first job. That way you’ll be an expert in no time, and the next time you have to do a job search you’ll have companies fighting to hire you.

--- a/packages/content/writing/accessible-icon-buttons.md
+++ b/packages/content/writing/accessible-icon-buttons.md
@@ -1,0 +1,254 @@
+---
+title: Accessible icon buttons
+date: 2020-09-02
+tags:
+  - front-end
+  - accessibility
+---
+
+Accessibility matters. Especially in today's world where we perform essential aspects of our life online. Your bank, social media, email—all of it probably uses a web at some point or another.
+
+I'm not gonna dive too much into [the business case for accessibility](https://www.w3.org/WAI/business-case) in this post, that's for another time. But suffice it to say that web accessibility is essential for any business operating a website. Two immediate reasons to care are the [legal risk](https://www.w3.org/WAI/business-case/#minimize-legal-risk) of inaccessible products and that [~15% of the population](https://www.worldbank.org/en/topic/disability#1) is considered to have some type of long-term disability.
+
+Icon buttons are a fairly common UI pattern in web apps. It's funny hearing about young kids seeing a floppy disk and exclaiming "You 3d-printed a save icon!" But it certainly illustrates the fact that we're acquainted with icon buttons and the actions that they represent.
+
+But what about people that can't see? How do they interact with icon buttons?
+
+Here's a couple principles for building icon buttons that everyone can use, whether or not they can see them.
+
+## Icon buttons should be _buttons_
+
+First things first, icon buttons should be a `button` element under the hood. Most screen readers rely on good HTML markup to properly announce what types of interactions are possible when an element is focused.
+
+Attaching `onclick` to a `div` may work if you're pointing and clicking in the app, but it makes interacting with the icon button impossible if you're on a screen reader. And while you can add other attributes to make the `div` accessible (like `aria-role`, `aria-label`, `tabindex`), it's not simple. And you're still not guaranteed it'll work properly in all screen readers 😭
+
+**My recommendation: just use a `button` under the hood.**
+
+## The problem: not enough information
+
+Before we go too far into how to make **good icon buttons**, let's look at why it's so common to see inaccessible icon buttons in today's web applications.
+
+Consider the follow non-icon button:
+
+```html
+<button>Click me!</button>
+```
+
+When focused on this button in a screen reader, I get the following message (this is using VoiceOver on macOS):
+
+```
+Click me!, button
+```
+
+The screen reader automatically picks up the **role** of the focused element (a "button") as well as the **label** on the button ("Click me!"). This is the same information that a sighted user has—they'll know it's a **button** from the way it's styled, and they'll know the **label** from the text directly inside the button.
+
+However, when we have an icon-only button, we end up with a different screen reader experience. Consider the following markup:
+
+```html
+<button>
+	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<!-- "refresh" icon -->
+	</svg>
+</button>
+```
+
+A user that can see the button knows it's a "refresh" action, and based on their experiences with other applications they know that if they click this button, it'll refresh some data.
+
+But what happens if we focus the button in a screen reader?
+
+This is all that we get:
+
+```
+button
+```
+
+If we're only using a screen reader to interact with our button, we have no clue **what** it does. For all we know, this button could refresh our data, delete it, or do something entirely different! And that's not a great experience 😱
+
+While we could always alter our designs to include **both** icons and text, sometimes that's not possible for a given design system. After all, a button with a simple icon has a nice, clean look.
+
+Fortunately there's a few ways that we can make something usable for **both** our sighted **and** our screen reader users.
+
+## Provide an invisible label for the screen reader
+
+The most important thing that we can do to make our icon button accessible is provide a label that's only for the screen reader. If you're looking at the button, it'll be exactly like the inaccessible version, but if you focus the icon in a screen reader you'll get some text telling you what this button does.
+
+There's 2 main ways to add this invisible button label.
+
+### Option #1: use "screen reader only" text
+
+The first way that we can provide text for the screen reader is by using **screen reader only** text.
+
+Essentially, we add text inside the button as if it had the icon **and** text. Then, we use some CSS magic to hide the text from sight.
+
+Here's the CSS that I usually use to make an HTML element invisible from sight, yet accessible to screen readers. It hides the content from sight and makes sure that the invisible content doesn't mess up any layouts either 🙌
+
+```css
+.visually-hidden {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}
+```
+
+_Note: if you're using [Bootstrap](https://getbootstrap.com/) you can use the `.sr-only` CSS class to create visually hidden content._
+
+It's important to note that we're **not** using `display: none` or `visibility: hidden` in our CSS. The reason for this is that applying either of these **removes** the element from the accessible DOM. Adding either one makes it impossible for a screen reader to "see" the content and read it out loud.
+
+Once you've got a `.visually-hidden` class written up, making our icon button accessible looks like this:
+
+```html
+<button>
+	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<!-- "refresh" icon -->
+	</svg>
+
+	<span class="visually-hidden">Refresh</span>
+</button>
+```
+
+All we need to add is that `span` with `Refresh` inside of it. Applying the `.visually-hidden` class makes the text invisible, so it looks exactly like the icon button from before.
+
+Finally, when we focus the button in a screen reader, we get the following:
+
+```
+Refresh, button
+```
+
+### Option #2: use `aria-label`
+
+An alternative approach to using a `.visually-hidden` CSS class is leveraging an `aria-label` on the `button` element itself. This overrides the default "label" that the screen reader would've read with the `aria-label` value:
+
+```html
+<button aria-label="Refresh">
+	<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+		<!-- "refresh" icon -->
+	</svg>
+</button>
+```
+
+This achieves the exact same screen reader output as the example with visually hidden text (at least in VoiceOver for macOS it does).
+
+## Hide the icon from the screen reader
+
+Another common practice when writing icon buttons is to add `aria-hidden="true"` to the icon itself. While I haven't any issues with VoiceOver for macOS reading the contents of SVGs, I think there's some screen readers that **do** announce the icon inside.
+
+```html
+<button>
+	<svg
+		aria-hidden="true"
+		xmlns="http://www.w3.org/2000/svg"
+		height="24"
+		viewBox="0 0 24 24"
+		width="24"
+	>
+		<!-- "refresh" icon -->
+	</svg>
+
+	<span class="visually-hidden">Refresh</span>
+</button>
+```
+
+`aria-hidden="true"` hides the icon from the screen reader—the inverse of how `.visually-hidden` made the text invisible to sighted users.
+
+## 🔥 Hot tip: require labels in icon button components
+
+Chances are you're using a front-end framework to build your web applications.
+
+At the same time, you car about creating accessible buttons—you don't want to alienate a large amount of potential customers by giving them something that isn't usable.
+
+One of the cool techniques I've used in a number of codebases is leveraging **components** to encourage accessible patterns. We can make accessibility the "default state" just by the way we structure our component APIs.
+
+**Strong, accessible components make it easy to do the "right" thing" and difficult to do the "wrong" thing.**
+
+For example, here's a way we could build an accessible icon button in React and TypeScript. I'm using the `Fab` nomenclature (**F**loating **A**ction **B**utton) from [Google's Material Design](https://material.io/components/buttons-floating-action-button).
+
+```tsx
+interface FabProps {
+	// Accessibility-only icon label
+	label: string;
+	// Markup for the icon itself
+	children: ReactNode;
+}
+
+const Fab = (props: FabProps) => {
+	return (
+		<button {...props} aria-label={props.label} className="fab">
+			{props.children}
+		</button>
+	);
+};
+```
+
+You'll notice in `FabProps` that `label` is **required** on the component. If it were optional we would have typed it with `label?: string`.
+
+This means that if you forget to provide a `label`, you'll get a compile-time error. You'll be **forced** to put _something_ (anything!) as `label`, guaranteeing that screen reader users get an equally usable experience.
+
+I've used this approach quite a bit and it works great most of the time. Whenever you forget to add an accessible label, that compiler error is usually enough to remind you to go add screen reader text.
+
+That said, there's still one edge case where we can sneak around the type system and make an inaccessible icon button:
+
+```tsx
+<Fab label="">
+	<svg>{/* svg content */}</svg>
+</Fab>
+```
+
+If we provide an empty label, we get around the type error, but we've still made an icon button that doesn't work on screen readers 😱
+
+This case can be guarded against with thorough pull request reviews as well as a team that's educated on accessible HTML. If you're used to seeing `label` with a value, seeing `label=""` is a huge red flag!
+
+But if you want to protect against this case **in the code itself**, you'll need to do some type of run-time checking. For instance, we could do augment our `Fab` to guard against any `label` prop that's empty.
+
+```tsx
+const Fab = (props: FabProps) => {
+	// Only have the error if NODE_ENV === 'development' and label is empty.
+	// This global __DEV__ variable assumes a setup like
+	// https://github.com/formium/tsdx#advanced-babel-plugin-dev-expressions
+	if (__DEV__ && !props.label) {
+		// If you want to be more aggressive with the error, you can actually
+		// `throw` an error here.
+		console.error(`
+      You have not provided an accessible label for this icon button. 
+      Please add some content to the "label" prop to remove this error.
+
+      For further reading about providing accessible labels, please refer to 
+      https://dequeuniversity.com/rules/axe/3.2/button-name.
+    `);
+	}
+
+	return (
+		<button {...props} aria-label={props.label} className="fab">
+			{props.children}
+		</button>
+	);
+};
+```
+
+This adds a **dev-only error** so that using the component with `label=""` creates a warning for the developer, but doesn't crash the app or anything. We've also made the error message educational and actionable—you know exactly what needs to be done to get rid of the message.
+
+As an added benefit `console.error` is enough to fail unit tests (if you're using Jest, at least)!
+
+> **Note:** _If you're not using TypeScript this approach provides a similar level of
+> developer protection against missing `label` props. Depending on your tooling
+> you might also be able to strip out the dev warnings for your production build
+> as well (that way you don't bloat your JS bundles)._
+
+## tl;dr
+
+Icon buttons should have an accessible label so screen readers can interact with them. The easiest ways to do this are visually hidden text or an `aria-label` attribute.
+
+---
+
+## Additional resources
+
+- [Accessible Icon Buttons](https://www.sarasoueidan.com/blog/accessible-icon-buttons/) by Sara Soueidan.
+- [Accessible Icon Buttons](https://egghead.io/lessons/aria-accessible-icon-buttons) Egghead course taught by [Marcy Sutton](https://twitter.com/marcysutton)
+- [Deque University "button name" rule](https://dequeuniversity.com/rules/axe/3.2/button-name).
+  If you're using [axe accessibility audit](https://www.deque.com/axe/) to check your markup you'll be linked to this page every time you have inaccessible button text.

--- a/packages/content/writing/adding-pipelines-to-javascript.md
+++ b/packages/content/writing/adding-pipelines-to-javascript.md
@@ -1,0 +1,13 @@
+---
+title: 'Adding pipelines to JavaScript'
+description: In this article I examine one of ECMAScript's exciting new proposals which adds a pipeline operator to JavaScript.
+
+date: 2018-11-19
+publisher: LogRocket
+link: https://blog.logrocket.com/adding-pipelines-to-javascript-f79ae7311574/
+tags:
+  - functional-programming
+  - javascript
+---
+
+In this article I examine one of ECMAScript's exciting new proposals which adds a pipeline operator to JavaScript. Pipelines offer a clean method of composing functions, and it's cool to play around with them in JavaScript.

--- a/packages/content/writing/april-may-2022-update.md
+++ b/packages/content/writing/april-may-2022-update.md
@@ -1,0 +1,26 @@
+---
+title: April/May 2022 update
+date: 2022-06-03
+tags:
+  - updates
+  - writing
+---
+
+April & May have been quite busy, but figured I'd drop a quick update on what I've been up to.
+
+## Full-time parenting 🐣
+
+I spent all of April & May on parental leave. And boy, did we need it!
+
+Being a parent is _not_ easy, but it is ✨ _so_ ✨ rewarding. I'm very grateful to my employer for these 10 weeks of time to spend caring for my wife and son. I don't know what we would have done without it.
+
+## Principal engineer! 🧑‍💻
+
+I did get one work call while on leave. I've been promoted from Staff Engineer to Principal Engineer at [Panther](https://panther.com/)! I'm looking forward to exploring what this means in practice as I return from leave and continuing to build delightful frontend security workflows.
+
+## Misc. updates 🤓
+
+- Been playing **much more** with [Remix](https://remix.run/) and I can firmly say I'm excited about it.
+- I rewrote this website in Remix, and saw things become much simpler as a result! Win-win!
+- Been reading [Designing Data Intensive Applications](https://www.amazon.com/Designing-Data-Intensive-Applications-Reliable-Maintainable/dp/1449373321) by Martin Kleppmann. While I'm more of a frontend specialist, I do regularly find myself working on distributed systems and collaborating with backend engineers. It's been a fascinating, in-depth look into what distributed systems have to deal with.
+- It's been an unusually wet spring in the PNW, so I haven't got to spend as much time outdoors as I expected. But I'm excited for the summer months when we'll be able to spend some time outdoors!

--- a/packages/content/writing/arrange-act-assert.md
+++ b/packages/content/writing/arrange-act-assert.md
@@ -1,0 +1,40 @@
+---
+title: Arrange, Act, Assert
+date: 2020-10-17T19:29:32.251Z
+tags:
+  - testing
+---
+
+One pattern I find helpful for writing automated tests is "Arrange, Act, Assert". Using this pattern, we can break up every test into three parts.
+
+## 1. Arrange
+
+First, you set up anything in the test environment that your code needs.
+
+Some examples of this include creating mock functions, seeding a database with test data, resetting the date/time, and creating global variables.
+
+The goal during this step is to create a controlled, predictable environment for your test to run in.
+
+> _**This phase is optional.** Some tests don't require you to set up the test environment and that's totally fine._
+
+## 2. Act
+
+This is where we actually run the code we want to test.
+
+If you're writing tests for a React component, render the component. If you're writing tests for a function, call the function and pass in some arguments.
+
+## 3. Assert
+
+Finally, the "Assert" step is where you check your code. You'll make sure that whatever you ran in the "Act" step did what it should have done.
+
+If you're using Jest or Chai this would be where you call `expect` with something like `toEqual`.
+
+Most assertions follow the format of `expect(result).toEqual(expectedOutput)` (This is Jest's syntax).
+
+> _Some people will tell you that you should only have 1 assertion per test. I don't agree with this, I think it's a little dogmatic and restraining. The number of assertions that you need may vary from test to test._
+
+## Conclusion
+
+I've found this pattern extremely helpful when writing my own tests and when teaching software testing. I think the "AAA" initials make it easier to remember and breaking out the tests into 3 separate phases makes it easy to focus on one thing at a time.
+
+As you write more and more tests throughout your career, you might find that you're thinking less about which step of the test you're in. You might find yourself cycling between all three multiple times on a single test. That's ok! This approach isn't dogma or "The One True Way", it's just a helpful way to think about the parts of an automated test.

--- a/packages/content/writing/audit-all-npm-dependencies.md
+++ b/packages/content/writing/audit-all-npm-dependencies.md
@@ -1,0 +1,99 @@
+---
+title: Audit all NPM dependencies in a project using this bash script
+date: 2020-07-02
+draft: false
+tags:
+  - bash
+  - automation
+  - npm
+---
+
+## Intro
+
+It's no secret that the JavaScript ecosystem is built on the backbone of OSS. Need a fully-featured front-end framework with all the batteries included? Only an `npm install` away. Need to parse a URL query string? `npm install querystring`. Want some padding before the start of your string? `leftpad` to the rescue! Chances are, any substantially large project built in JavaScript will have _some_ OSS dependencies, if not _many_.
+
+_Note: this isn't a post about when you should install an NPM package vs when you should write some custom code. That is certainly a long, nuanced discussion that merits its own post!_
+
+However, when you start diving into the _legal_ aspects of OSS, you'll quickly find that there are _**a bunch of different open source licenses**_. MIT, Apache-2.0, GPL, MPL-2.0, WTFPL, the list can go on and on.
+
+The differences between these licenses can be nuanced and difficult to understand. 😭 But as an engineer working with open source software, it's important that we know the implications of the license that we're using. But that's a different post altogether! 😅
+
+Even if you're being diligent to only use licenses that you have permission to use, it's still likely that your company's legal team is going to want to check this at some point. And that makes sense, it's their job to check this type stuff and make sure that the company isn't headed towards legal problems from software licensing issues.
+
+This exact situation has happened to me a few times now over the course of a project I've been working on for one of our clients. As a team lead, these types of requests often fall on my plate. The first time I went through every single repository for the project and started copying the licenses (`yarn licenses list`) into a document.
+
+Talk about tedious. 😱
+
+But then I had a thought.
+
+Isn't this what writing code is for—getting computers to automate away all the boring, repetitive tasks, so that we can focus on more important things?
+
+So here's my script for automating away this problem!
+
+## Prerequisites to run this script
+
+I know this script isn't bullet-proof—it's something I've been using in my personal development to solve a problem. As a result, it's somewhat tailored to my own workflow.
+
+So before we get to the code, a couple disclaimers.
+
+**This script is Zsh-specific.** I use Zsh along with the fantastic [git aliases](https://github.com/ohmyzsh/ohmyzsh/wiki/Cheatsheet#git) that come built-in with Oh My Zsh. As a result some of the git operations (like `ggl` for `git pull origin` and `gco` for `git checkout`) might not work if you run this in regular ol' Bash.
+
+_I might circle back around and update this to be completely Bash someday, but it's not really that high on my priority list. If you want to submit a PR to this article to update the snippet I'm more than happy to merge it!_
+
+**This script is built assuming the following directory structure.** Since I'm currently working as a consultant and it's possible that we might have code for different clients on the same computer, I use the following directory structure on my work machine.
+
+```bash
+work
+└─ client-a
+│     └─  repo-1
+│     └─  repo-2
+└─ client-b
+│     └─  repo-1
+```
+
+This snippet is built to run inside of the `client-a` repository, and would provide you with all the licenses used in both `repo-1` and `repo-2` as a single text file (`licenses.txt`).
+
+## Enough already, show me the code!
+
+Without further ado, here's the code:
+
+```bash
+# We go thru the directories and update the git branches in a SEPARATE
+# loop so that we can easily see whether there were any issues with updating
+# the master branch (for example, you have changed files on a branch that
+# would be overwritten by merging master).
+for d in */;
+# $d is the directory name
+do
+  SEPARATOR="\n--------------------\n"
+  echo "$SEPARATOR $d $SEPARATOR";
+  # Putting this line in parentheses makes the terminal cd out of the
+  # directory after all of the commands in the parentheses have exited.
+  (cd $d && gco master && ggl);
+done;
+
+# Clean out the file if it was preexisting
+rm licenses-2020-07-02.txt;
+# Create a new blank file
+touch licenses-2020-07-02.txt;
+
+# Loop thru every directory in the folder containing all of the repos.
+# This 2nd loop is where we are going to aggregate all of the licenses into
+# the licenses file.
+for d in */;
+# $d is the directory name
+do
+  HEADING="\n-------------------------\n $d \n-------------------------\n";
+
+  # Print out a header with the repo name,
+  # append (>>) this to the licenses file.
+  echo $HEADING >> licenses-2020-07-02.txt;
+
+  # Go into the directory and print the licenses
+  # append them to the licenses file as well.
+  (cd $d && yarn licenses list) >> licenses-2020-07-02.txt;
+  echo "✅ Audited licenses for '$d'."
+done;
+```
+
+If this code was useful to you and helped you solve real-world problems, I'd love to hear about it! Feel free to reach out to me on my [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (reference this article so I know it's not spam!). Thanks for reading!

--- a/packages/content/writing/clean-console-using-chrome-devtools-to-stop-logging-to-the-console.md
+++ b/packages/content/writing/clean-console-using-chrome-devtools-to-stop-logging-to-the-console.md
@@ -1,0 +1,87 @@
+---
+title: Clean Console
+description: Using Chrome DevTools to Inspect JSON Responses from API Requests
+date: 2018-02-01
+image:
+  url: 'tools.jpg'
+  alt: Tools at a workdesk
+---
+
+I’ve been fortunate to instruct and work with many people that are beginning to code through the very same bootcamp I attended about a year and a half ago ([Thinkful](https://www.thinkful.com/) &mdash; yes this is a shameless plug 😜 ). Most recently I’ve been doing a series of workshops on Chrome Devtools, where I teach common parts of Chrome DevTools that many front end developers are using daily. One of the most common inefficiencies I’ve noticed is using `console.log` to preview JSON responses from an API.
+
+I didn't learn how to use Chrome DevTools until I got on my first gig. I knew how to do the basics &mdash; preview CSS changes, change HTML, basically a bit of the stuff inside the `Elements` tab.
+
+I've also heard similar stories from some of my colleagues at my current job &mdash; debugging & developer tools aren't usually learned until _after_ people get out on their first gig. One reason is that 3–6 months is a short time to learn how to program, much less learn how to use developer tools well (but I digress…maybe that’s another blog post).
+
+My most recent workshop focused on the Chrome DevTools "Network" tab: how to analyze your load time & other "productivity hacks" I've picked up.
+
+## The Problem: Log, Log, Everywhere
+
+One of the earlier lessons in the process of learning web development is learning about fetching data via AJAX. Most apps that goes beyond triviality or need to respond to data dynamically are gonna fetch some JSON from an API, and then operate on that JSON.
+
+Many times, I would find myself doing something like this in my source code so that I could preview the JSON response.
+
+```javascript
+fetch('https://jsonplaceholder.typicode.com/posts')
+	.then((res) => res.json())
+	.then((json) => {
+		console.log(json); // to see what the response was
+		// code operate on the JSON goes here
+	});
+```
+
+To preview my JSON, I would either scatter console.log all over my codebase and dig through the browser console window to find my JSON, or I would copy-paste the endpoint into Postman or a cURL request. All of these work, but **what if there was a faster way to debug JSON responses in the browser?**
+
+---
+
+## Chrome DevTools To the Rescue!
+
+Thanks to Chrome DevTools, we can preview our JSON _without touching our source code_ (read: higher productivity & a smaller chance that you accidentally forget to delete a `console.log`).
+
+### 1. Open the Network Tab
+
+I’m going to demonstrate all of this on one of my own apps, called [Horizon](https://benjaminj6.github.io/horizon). It's essentially a sunset tracker, pulling data from https://sunrise-sunset.org/. You're welcome to follow along or use any app of your choice, provided it sends JSON over the internet.
+
+First, since we're gonna be debugging via the Network Tab, we'll want to open that up. Once you've got it open, you'll see something like this.
+
+![network tab open](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120282/network_tab_open_xwckl5.png)
+
+Great! Now we're all set to start our debugging.
+
+### 2. Filter by `XHR`
+
+While my sample app may not have a ton of requests, many apps can contain 100+ requests on initial page load, making it a little more difficult to find the specific AJAX request we're looking for.
+
+Fortunately, Chrome DevTools lets us filter by response type. You'll see all of the options available to you near the top bar. Select **`XHR`** (this stands for **X**ml**H**ttp**R**equest), which contains all JSON data pulled into the app via `fetch` (or `$.ajax`, `axios`, or whatever way you're using to grab your data).
+
+With the response filtered, your Network Tab should look like this:
+
+![network tab filtered](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120282/devtools_filter_xhr_bfh1x5.png)
+
+That's really slick! Now we only have to parse through a few requests to find what we're looking for.
+
+### 3. Inspect & Preview...Voila!
+
+Find the request that you're interested in. Click on the request and you should see a menu like this pop up.
+
+![network request inspect](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120283/devtools_view_request_rvmirk.png)
+
+The final step is for us to select that `Preview` tab. Once selected, you should see something like this.
+
+![preview pane with json](https://res.cloudinary.com/da2iq7dge/image/upload/v1517120282/devtools_preview_json_re3xgb.png)
+
+There's our JSON! We've successfully found it _without touching our source code_. This means we can use this method of debugging _anywhere we can use Chrome DevTools_ &mdash; including debugging sites in production with minified JavaScript.
+
+---
+
+## Conclusion
+
+If you’re a seasoned pro and read all the way to the end, you might be thinking, “I’ve known this for years, people have really never learned this?”
+
+When I first discovered this method of debugging network requests, I felt like I had just been given superpowers. I’m grateful for the developers in my career that taught me how to use tools and increase my productivity. A well-placed `console.log` can be an extremely effective tool, but scattering it all over source code felt much like the whole "Maslow's Hammer" dilemma:
+
+> I suppose it is tempting, if the only tool you have is a hammer, to treat everything as if it were a nail.
+>
+> — Abraham Maslow, 1966
+
+As always, if you read this post and enjoyed it, I'd love to know! Shoot me a tweet on my [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/).

--- a/packages/content/writing/conventional-commits.md
+++ b/packages/content/writing/conventional-commits.md
@@ -1,0 +1,63 @@
+---
+title: Conventional Commits
+date: 2022-11-23
+tags:
+  - teamwork
+  - software-engineering
+  - cheat-sheets
+---
+
+## Why?
+
+Conventional commits are useful for a number of reasons, but the most useful to me are:
+
+1. You can succinctly note the nature of the change you are making in each commit.
+2. You can auto-generate semantic versions based on the prefix + breaking change notation.
+
+The first is useful regardless of whether other engineers follow conventional commit format, while the second requires you to set up automation and enforce all commits to be in the conventional format.
+
+I find myself using the conventional commit prefixes fairly frequently, and am always looking them up, so that's why I wrote this cheat sheet. 😎
+
+Here's some of the most common ones.
+
+## Commit prefixes
+
+| prefix      | meaning                                                       |
+| ----------- | ------------------------------------------------------------- |
+| `feat:`     | A new product feature                                         |
+| `fix:`      | Fixing a bug                                                  |
+| `refactor:` | Refactoring code, no new features                             |
+| `docs:`     | Updating documentation                                        |
+| `style:`    | Formatting changes to code only                               |
+| `test:`     | Changing / fixing tests                                       |
+| `ci:`       | Changes to CI builds                                          |
+| `build:`    | Changes to build system, deployment, etc                      |
+| `chore:`    | Cleanup, renaming, organizing, etc. Catch-all for small tasks |
+
+## Conventional commit format
+
+In general, conventional commits use the following structure:
+
+```
+{prefix}: {description}
+
+fix: reorder modal z-index
+```
+
+Optionally, you can include a "scope" of your change:
+
+```
+{prefix}({scope}): {description}
+fix(homepage): reorder modal z-index
+```
+
+Finally, if your commit introduces a breaking change, you can include an exclamation point:
+
+```
+{prefix}!: {description}
+feat!: new routing API
+```
+
+## Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)

--- a/packages/content/writing/copy-to-clipboard.md
+++ b/packages/content/writing/copy-to-clipboard.md
@@ -1,0 +1,81 @@
+---
+title: copyToClipboard
+subtitle: Function that copies an input value to the system clipboard
+date: 2020-12-22
+tags:
+  - typescript
+  - recipes
+---
+
+```ts
+export const copyToClipboard = (input: string) => {
+	const $el = document.createElement('textarea');
+	$el.value = input;
+
+	// Make sure we hide the element from sight
+	$el.setAttribute('readonly', '');
+	$el.style.position = 'absolute';
+	$el.style.left = '-9999px';
+
+	document.body.appendChild($el);
+
+	// Select the input, this is the same as dragging your cursor over it.
+	$el.select();
+	// Copy the current selection to the clipboard
+	document.execCommand('copy');
+
+	// Finally, clean up after ourselves
+	document.body.removeChild($el);
+};
+```
+
+## Context
+
+Surprisingly, copying arbitrary input to the system clipboard (`CMD + C` / `CTRL + C`) isn't provided by default in the DOM.
+
+As a result we need to create our own function to create those `Copy to clipboard` buttons you see all over the place.
+
+This is the exact same version of the `copyToClipboard` function that's used on this website for the code snippets.
+
+## How it works
+
+Under the hood, `copyToClipboard` creates an invisible `textarea` and inserts it into the DOM. We can then use _this element_ to execute the DOM commands to select the text and copy to clipboard.
+
+One consideration is that selecting the text of a hidden `textarea` might focus the document, which could potentially be problematic for screen reader users.
+
+## Usage
+
+```ts
+// This could be anything—an API token, code sample, etc.
+const inputContents = '1234-5678-91011';
+
+// Then you just pass your input into the function! You can attach it to
+// a click event like you normally would in raw JS / your framework of choice.
+copyToClipboard(inputContents);
+```
+
+## Tests
+
+This function's actually a little nasty to test in `jest` since JSDOM doesn't support `document.execCommand`. So you can test that the clipboard command was executed, but you can't _actually_ access clipboard contents in JSOM.
+
+```ts
+import { copyToClipboard } from '../copyToClipboard';
+
+const originalExecCommand = document.execCommand;
+
+beforeEach(() => {
+	document.execCommand = jest.fn();
+});
+
+afterEach(() => {
+	document.execCommand = originalExecCommand;
+});
+
+test("should copy the input to the user's clipboard", () => {
+	copyToClipboard('test clipboard');
+	// We can't test the actual clipboard contents, but we can test that
+	// the `execCommand` function was properly fired.
+	expect(document.execCommand).toHaveBeenCalledTimes(1);
+	expect(document.execCommand).toHaveBeenCalledWith('copy');
+});
+```

--- a/packages/content/writing/cra-to-nextjs.md
+++ b/packages/content/writing/cra-to-nextjs.md
@@ -1,0 +1,80 @@
+---
+title: Lessons from our ~7 month migration to Next.js
+date: 2024-04-27
+tags:
+  - nextjs
+---
+
+In October 2023 I completed a migration from Create-React-App (CRA) to Next.js at [work](https://sublime.security/).
+
+Before I get too far into what I _learned_ from this migration, a quick word — this post isn't about why you should migrate to Next.js. It's also not a tutorial.
+
+However, answering "why?" and "how?" is essential for any successful migration, so I'll offer a quick summary.
+
+## why?
+
+This [Github comment](https://github.com/facebook/create-react-app/issues/11180#issuecomment-874748552) summarizes the reasons we got off of CRA. In short, it wasn't ever intended for production-grade software applications, and our app was suffering from a good deal of [accidental complexity](https://worrydream.com/refs/Brooks_1986_-_No_Silver_Bullet.pdf) as a result of being on top of CRA and React Router.
+
+We picked Next.js because we could incrementally migrate without immediate changes to the architecture (keep the same bundler, rendering techniques, infrastructure, etc). Secondly, at the time (March 2023) it was more established and stable than the alternatives, and I have a good deal of history with Next.js which de-risked some unknowns.
+
+_Sidenote — I know it's become trendy to hate on Next.js' instability. I've been using it since v3 and have not had difficulty upgrading. But your experience may be different!_
+
+## how?
+
+Our migration followed a fairly standard "[strangler fig](https://martinfowler.com/bliki/StranglerFigApplication.html)" pattern — we wrapped the existing React Router app inside a catch-all route. Then we migrated route-by-route until there were none left.
+
+On the infrastructure front, we kept the existing Docker image (nginx) as-is, serving a fully client-rendered application. The initial plan was to migrate all of the routes first, and swap to a Node.js image at the end. However, we ended up swapping the image to Node.js in the 3rd week to solve some product bugs (needed some route rewrites on some third-party APIs, and also needed server rendering for some routes to have better SEO).
+
+In total, the migration ran from March 2023 to October 2023. For the first few months it was just myself, and in the last few months of the migration there was another engineer working on route migration alongside me.
+
+Finally, we only had ~2 weeks where we were working on the migration full-time — for the bulk of it we were migrating 1-2 routes when we had spare chunks of time. The rest of our time was spent on regular feature development.
+
+## lessons learned
+
+Overall, I'm proud of the migration and consider it a success — we're a small team, and we were able to ship a major architectural improvement without (too many) hiccups. We also did not pause on shipping customer-facing features over the course of the migration.
+
+I didn't expect it to take me ~6 months to sit down and write about the migration. However, one benefit is that I've had a good amount of time to reflect on what I'd like to highlight about it.
+
+### plan in shippable chunks
+
+Don't plan to ship your migration in one go. Instead, plan the migration so that you can ship pieces incrementally.
+
+This vastly decreases the level of risk you take on. You may hit the exact same bugs, but you've smeared them over weeks / months instead of a single release. You'll probably notice them (and fix them) long before your users do.
+
+You can also hit "pause" on the migration at any point. This allows you to respond to real business needs. You can ship new features, fix bugs, go on-call, etc — all while making sure that the migration progresses forward, step by step.
+
+Incremental, pausable chunks is the only way to safely finish the migration without losing your sanity. You may never need to hit pause, but more often than not you'll need that option to be available.
+
+### provide actual business value
+
+If you want your migration to be considered a success it needs to provide some actual value to the business.
+
+Granted, business value™ has a lot of flavors. Sometimes it's a direct line between the code and the money it brought in. Other times it's fuzzier things like "dev productivity".
+
+In our case, Next.js opened a few doors early-on. More specifically, it afforded us an easy way to proxy some third-party dependencies, and it allowed us to build a couple features (dynamic og images) that would have been tricky without it.
+
+We've also gotten some of the fuzzier business value as well — we removed a bunch of outdated dependencies, our dev server starts faster, and our codebase has a bit more structure.
+
+### limit concurrent migrations
+
+One danger with incremental migrations is never finishing them. Every time you hit pause, you risk never hitting play again. Then your codebase gets permanently stuck in limbo.
+
+However, you can intentionally limit how many migrations you take on. Deliberately holding off on starting that next migration until you've finished the one on your plate. We had a few migrations (forms, data tables, some UI elements) that we intentionally delayed until we finished Next.js.
+
+Make sure not to stretch yourself too thin — we're only human after all.
+
+### keep the handoffs simple
+
+One initial mistake that I made was adding a fancy handoff between the React Router and Next portions of the app. I made a special `MigrationLink` component that knew which router it was jumping into based on the link. The goal was to allow seamless client-side routing, even when crossing across the router boundary.
+
+That turned out to be a huge, buggy mess.
+
+Eventually we stopped using `MigrationLink` in favor of just rendering a raw `a` tag every time we crossed the router boundary. This ended up being much simpler and less buggy, at the cost of a full-page refresh.
+
+By simplifying the boundary between the two systems we made the migration much more stable and created less mess for ourselves to clean up later. And our customers didn't mind!
+
+## final thoughts
+
+This post is long overdue — while completing the migration was one thing, collecting my thoughts and sitting down to write an article took just as long as the migration! 😅
+
+I'm very proud of the work that we did — I've seen a lot of "big bang" migrations over my career, but not as many incremental, pausable migrations. Since joining Sublime Security I've done a handful of these incremental migrations and I'm firmly becoming convinced that it's _the best way_ to ship large architectural changes.

--- a/packages/content/writing/dev-only-routes-in-nextjs.md
+++ b/packages/content/writing/dev-only-routes-in-nextjs.md
@@ -1,0 +1,96 @@
+---
+title: Dev-only routes in NextJS
+date: 2020-09-05
+tags:
+  - nextjs
+  - front-end
+---
+
+I've found myself often wishing that NextJS had a way to optionally hide **entire pages** from the production builds.
+
+For example, on this website I have a small design system—it helps me keeps things like colors, spacing, and border-radii consistent. I also have a single page containing all my components so that I can easily workshop and test them. However, that's a page that I don't see too much value in sharing with the entire world (yet)—it's just a dev tool for myself.
+
+For a big-scale design system (like what you'd build at a company), you'd likely have a separate repository with something like [Storybook](https://storybook.js.org/), [Playroom](https://github.com/seek-oss/playroom), or [StyleGuidist](https://react-styleguidist.js.org/) set up. However, that can be a large amount of overhead to maintain—especially if you're a small team (or a single dev). Sometimes the size of the project doesn't justify having a separate repo of components.
+
+NextJS doesn't have anything built-in that lets us optionally hide a page (to my knowledge), but we can use a couple of its page-creation APIs to achieve the exact same experience.
+
+---
+
+## tl;dr
+
+We can leverage NextJS' [dynamic routes](https://nextjs.org/docs/routing/dynamic-routes) and [`getStaticPaths`](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation) to optionally render routes based on environment variables. This is useful for things like website documentation and partially finished work.
+
+---
+
+## What are the "specs"? 📝
+
+Before we dive into the code, let's define exactly what we want to achieve. For me, it's a couple things:
+
+- Whether we enable the page should be adjustable with an _environment variable_. This fits in nicely with [12-factor app](https://12factor.net/config) philosophy.
+- If the page is not enabled, _its route should return a 404 response_, as if the page never existed.
+- If the page is enabled, _it should display the content_ normally.
+
+## Show me the code! 🙃
+
+To leverage this approach, we'd need to place the following page code in a file within the `pages` directory. To properly leverage dynamic routing, we also need the filename to be encased in square brackets. For example, `pages/docs/[component].jsx`.
+
+```jsx
+// pages/docs/[component].jsx
+
+const DevOnlyPage = () => {
+	return <div>test!</div>;
+};
+
+// Even though there isn't any "dynamic" data flowing into our page component
+// we can leverage `getStaticPaths` to dynamically determine _which_ pages should
+// be built.
+export const getStaticPaths = () => {
+	const paths = [];
+
+	// If the environment variable is available, push some pages. This gives you
+	// fine-grained control over whether or not pages are added.
+	if (process.env.BUILD_DOCS === 'true') {
+		// `component` lines up to the page name of [component].jsx
+		paths.push({ params: { component: 'design-system' } });
+	}
+
+	// If `paths` is empty, all paths at this route will return 404 responses, same
+	// as if we never had the page at all.
+	return {
+		paths,
+		// This is important, using `fallback: false` means that all routes not
+		// returned from this function return 404 responses.
+		fallback: false
+	};
+};
+
+// Even though we're not dynamically getting any props, `getStaticPaths` doesn't
+// work without `getStaticProps`.
+export const getStaticProps = () => {
+	return {
+		props: {}
+	};
+};
+
+export default DevOnlyPage;
+```
+
+## Trade-offs
+
+One of the big tradeoffs of this approach is that you _have_ to use NextJS' dynamic routes and `getStaticPaths`. This potentially breaks away from NextJS' opinionated "every route is a page component" philosophy if you have multiple pages under a single route (i.e. `/docs/design` and `docs/architecture`).
+
+If you have multiple dev-only pages on a parent route, you might need some lightweight conditional logic in your page component. You can return the page name from `getStaticProps` and use that to conditionally render each dev-only component.
+
+One potential workaround (I haven't tried it yet) is using an [_optional catch-all route_](https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes) to do the dynamic routing. This might make multiple dev-only routes a little simpler.
+
+## Some potential use cases 🤔
+
+Here's a couple cases where I think an approach like this could be useful:
+
+- Previewing your design system. This was the original use case that made me investigate this approach.
+- Partially finished work. For example, if you're building a new page that's gonna take a multiple PRs but you don't want to expose it. You can use this approach as a simple method of feature-flagging routes to keep them out of production.
+- This approach could be a nice way to host dev-only documentation (for example, [ADRs](https://github.blog/2020-08-13-why-write-adrs/)) without exposing it in your production environments.
+
+---
+
+Thanks for reading! As always, feel free to [let me know on Twitter](https://twitter.com/benjamminj) if you enjoyed the article or [submit a PR](https://github.com/benjamminj/portfolio) if you found a typo!

--- a/packages/content/writing/empathetic-code.md
+++ b/packages/content/writing/empathetic-code.md
@@ -1,0 +1,77 @@
+---
+title: Coding with empathy
+description: It's important to write code with emotional awareness. When we forget that code is also for humans to read, we end up with scary codebases that make the future maintainers of our code sad.
+date: 2019-02-07
+image:
+  url: 'battle-board-game-pieces.jpg'
+  alt: A team of four game pieces stand in a row
+tags:
+  - teamwork
+  - software-engineering
+---
+
+I'm a big fan of [April Wensel](https://compassionatecoding.com/) and her talks on "compassionate code". I love how she drives home the point that software engineering is fundamentally about working with other humans. Yes, it is incredibly important that we have technical expertise, but we also need to be experts in collaboration.
+
+In order to collaborate effectively we need to be engineers that have a high degree of _emotional intelligence_. And while this certainly means decreasing workplace toxicity, emotional intelligence also extends to the code we write. That's what we'll be exploring in this post—writing code with empathy in mind.
+
+## But how can code be empathetic?
+
+It's a good question to ask. After all, we often think of empathy as something connected to our interactions with other people, and we think of code as the time when we get to be "purely technical".
+
+However, as authors of the code we write, we have an opportunity to practice empathy for our code's future maintainers. When we write code that takes into account how future maintainers will feel reading it, we approach our job differently. All of a sudden it become less about just getting things to work or pushing out feature after feature. Instead we start to care about maintainability, readability, and simplicity.
+
+There's a familiar programming quote from [Code For The Maintainer](http://wiki.c2.com/?CodeForTheMaintainer) that emphasizes this aspect of empathy (along with a little melodrama).
+
+> “Always code as if the person who ends up maintaining your code is a violent psychopath who knows where you live.”
+
+What I love about this quote is that it taps into our survival instinct to remind us that it's important to think of the future people that will maintain the code we write today. Sometimes that future maintainer is yourself, sometimes it's someone you've never met. And while it's rare that the future maintainer is gonna come stalking you with murderous intent, they are still human. It's vital that we write code that makes their job a joy—not a living hell.
+
+## So how do we write empathetic code?
+
+A lot of the software industry loves this idea of code being "clean", first introduced by Robert Martin in his book "[Clean Code](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882)". And while I like a ton of these clean coding principles, I think we miss a lot if we only focus on "best practices" or a list rules to make our code "clean" or "unclean".
+
+Instead, I think it's important for us to frame these software "best practices" through the lens of empathy and how they affect the people that consume our code (perhaps other developers using an internal module's API) or make updates to our code. That way it becomes less of a checklist of things that we "have to do" and more established into the _way that we do things_.
+
+Let's take a quick look at some of these software practices, framed through the lens of empathy:
+
+### Automated Tests
+
+Tests are a great way to provide long-term safety to a module of code. By automatically verifying that the code works, they serve as one of the first line of defense against costly bugs and regressions. When I open up a file for the first time and see that it has some comprehensive test coverage, I feel complete freedom to make whatever changes I need to—without the fear of breaking things! By contrast, opening a file without any tests can be downright terrifying. When we write tests we're not only saving our business [time and money](https://medium.com/javascript-scene/the-outrageous-cost-of-skipping-tdd-code-reviews-57887064c412), we're making sure that the future maintainer of our code can feel safe about modifying it.
+
+### Consistent styling
+
+Having a consistent code style goes a long way towards making life easier for future maintainers. Syntax and formatting issues tend to be low-hanging fruit that can usually be automated with tools like [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/) (if you're writing JavaScript, for other languages you might need different tools).
+
+Having a consistent code style is empathetic because it allows your teammates to understand the code faster. Not forcing them to spend extra brain cycles reading through inconsistently formatted code allows them to focus on what actually matters: the problem they are trying to solve.
+
+### Choosing good variable names
+
+There's another quote from "Clean Code" that goes along the lines of "you should name every variable with the same care that you would give to naming your firstborn child".
+
+While the metaphor may be a bit hyperbolic, the point still stands: how you name things matters. By spending that extra (often small) effort up-front to choose a descriptive name, you help your team (and your future self) gain context about the code. In the moment we know extra context about _why_ our code is the way it is, so that's the best time to choose a descriptive variable name to remind future maintainers of that context.
+
+### Adding comments
+
+If you can't fit all of the context inside a variable name, leave a helpful comment along with whatever name you chose!
+
+You might have heard some people say that "code should be self-documenting so comments are unnecessary". While it is true that we should strive to make our _code_ as clear as possible, a well-placed comment can pack a ton of extra context that you wouldn't really be able to fit inside a variable.
+
+I'm a big fan of using comments to explain the _why_ behind the code. We don't really need to comment that a `for` loop iterates through the list, but if it's there to solve a specific edge case it's helpful to know what that edge case is. Adding a comment can be super valuable when some future developer stumbles across that code and is trying to figure out exactly why it's in the codebase. That way they know whether it's safe to delete that code or not.
+
+### Documentation
+
+A great way to measure the empathy of your codebase is to watch what happens when a new team member comes on board. How long does it take for them to get the app running locally? What types of questions are they asking? What types of things are they "doing wrong" in their first few PRs?
+
+If you don't have any new team members coming onboard for a while, put yourself in the shoes of a junior developer starting their first day at your company. What types of things about your codebase would be confusing or unclear?
+
+One of the best ways to fight unclarity is through a good set of documentation. Having clear, well-written docs about getting the app running or performing certain tasks can go a long way towards making a codebase friendly and inviting instead of unclear and daunting.
+
+However, docs also have to be written with empathy in mind! Making sure that documentation is extensive enough to provide clarity while not coming across as belittling is a fine balance. One way that I try to assess the clarity of my docs is to "optimize for copy-paste". Assume that the person reading your documentation is going to copy-paste your examples into their code because they're trying to solve a complicated problem on a time crunch. Thinking about docs in this way forces you to write examples that are fully fleshed out.
+
+### And many more!
+
+This is definitely not an exhaustive list of the ways to make our code empathetic. In fact, any of the "best practices" out there could be looked at through the lens of empathy. Take a couple of the best practices that you're passionate about and think about how they positively impact future maintainers and you'll see what I'm talking about!
+
+## Conclusion
+
+At the end of the day, engineering is about communication—we tell the computer what operations to execute, and we tell our teammates what the code is supposed to do. And while the computer doesn't care about how empathetic our code is, our teammates and future maintainers do. By focusing on empathy in the code we write, we will produce higher quality software as a byproduct.

--- a/packages/content/writing/encapsulation-better-than-reuse.md
+++ b/packages/content/writing/encapsulation-better-than-reuse.md
@@ -1,0 +1,17 @@
+---
+title: Encapsulation > reusability
+description: Focus on encapsulation, and you'll get reusability as a byproduct.
+date: 2022-01-01
+tags:
+  - software-engineering
+---
+
+Encapsulate well and you'll get reusability for free. But it doesn't go two ways: a highly reusable module isn't necessarily well encapsulated.
+
+One reason encapsulation breeds reuse is due to the nature of _hiding information_. Encapsulation allows us to take complex information and stuff it in the closet. Instead of seeing all the complex mess, we've hidden it behind a simpler interface.
+
+In contrast, a module can remain highly reusable while exposing all its complexity. A [leaky abstraction](https://en.wikipedia.org/wiki/Leaky_abstraction) can be still be widely used. But there's a catch: to use it effectively you need to know how it works internally.
+
+If you want to get more reusable code, focus first on abstraction. Ask yourself, "what complexity does this module hide?" If the answer is "none", get rid of the module entirely. [Code that looks the similar isn't always the same.](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction)
+
+Reuse isn't the goal, it's the byproduct.

--- a/packages/content/writing/encapsulation.md
+++ b/packages/content/writing/encapsulation.md
@@ -1,0 +1,33 @@
+---
+title: Encapsulation
+date: 2022-01-01
+tags:
+  - software-engineering
+  - definitions
+---
+
+## tl;dr
+
+> _**Encapsulation:** hiding the specific information about a portion of code._
+
+---
+
+We have tons of examples of encapsulation outside the software world.
+
+When you drive a car, you don't need to know about everything happening inside the engine, you use the steering wheel & 2-3 pedals to control the whole thing.
+
+When you unlock a door, you're using a simpler interface for a [complex locking machanism](https://en.wikipedia.org/wiki/Lock_and_key). But all you do is insert the key, turn, and push.
+
+The same ideas apply to writing software, we use encapsulation all the time without thinking twice. Consider this sample JavaScript.
+
+```js
+JSON.parse(someJSONValue);
+```
+
+When you call `JSON.parse`, you don't need to know everything about _how_ the JSON gets parsed, you only need to know a few things: the JSON you want to parse, and that you get back a parsed JS object (or array).
+
+_(Yes, I know `JSON.parse` takes a couple arguments, but these are optional)._
+
+Encapsulation is fundamental for building large software systems. Hiding complex information about a module allows others to use that module to build bigger things. We allow the people to _focus_ on a single piece of an application without holding everything in their head at once.
+
+In short, encapsulation is the name of the game when it comes to software. we'd all do well to spend lots of brain cycles on encapsulating well.

--- a/packages/content/writing/engineering-values.md
+++ b/packages/content/writing/engineering-values.md
@@ -1,0 +1,127 @@
+---
+title: Engineering values
+date: 2020-10-30T22:21:15.099Z
+tags:
+  - software-engineering
+  - philosophy
+---
+
+Recently I've been thinking about high-level values as they pertain to software engineering.
+
+You can tell a lot about an engineering team by their **practices**, but that won't tell you the **values** driving those practices. Engineering values serve as a guiding light driving engineering practices. Rather than a list of rules to follow, values give us the "why" behind the things we do.
+
+## A couple caveats
+
+First, this list isn't exhaustive. There's probably things that I forgot. There's probably things that I'll add as time goes on.
+
+Second, this is a living document. I plan on coming back to this periodically as my views and engineering values evolve.
+
+Finally, if you don't do everything here, that doesn't instantly make you a "bad" engineer. Some of these practices are things I'm currently learning and haven't had extensive experience in.
+
+---
+
+## People first
+
+> _Software development is about real people. Code has two primary audiences—the developers coding on top of it (internal) and people using it (external)._
+
+While programming can be artistic and code can be elegant—elegant code is not the end in and of itself. Rather, it's a path to the goal of serving these two audiences.
+
+You serve the internal audience (often future you!) when your code is easy to work with. You serve the external audience when they actually use the things that you create!
+
+### Supported engineering practices
+
+- Documentation
+- Code comments (commenting the "why")
+- Automatic formatters and linters
+- Intuitive APIs (well-thought-out, ergonomic, understandable interfaces)
+- Accessibility
+- ADRs
+- Good variable names
+- Developer experience (DX)
+- Automation (automate as much as is reasonably possible)
+- Simple code over clever code (however, "simple" is often up to interpretation)
+- Static type systems (TypeScript, Flow, ReasonML)
+- User testing & research
+- A/B testing
+- Timely refactoring (don't abstract too early)
+- Reasonable work hours (no death marches)
+
+## Duplication is better than bad abstractions
+
+> _Undoing a bad abstraction is more difficult than creating an abstraction for some duplication. Wait to write abstract "DRY" code until you know enough about what you need to create a good interface._
+
+This principle is heavily influenced by Sandi Metz's [The Wrong Abstraction](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction).
+
+### Supported engineering practices
+
+- Regular refactoring (both at dedicated times and as-you-go)
+- Automated tests (especially integration and end-to-end tests)
+- Static type systems
+- Code comments (commenting the "why")
+- "Hot garbage architecture"
+- Timely refactoring
+
+## Optimize for flexibility
+
+> _Changing requirements are to be expected, perhaps even the norm. Optimize code to be flexible and pliable so you can iterate on and polish it over time._
+
+### Supported engineering practices
+
+- Composition
+- Automated tests
+- Static type systems
+- Regular refactoring
+- Documentation
+- Code comments
+- ADRs
+- Timely refactoring
+- Continuous deployment
+- Continuous integration
+- Feature flags
+- Colocation of files (optimizing to delete code)
+- "Hot garbage architecture"
+- Pragmatic guidelines over dogmatic laws
+
+## Backwards compatability
+
+> _Don't break things. Have confidence that your new code doesn't break your old code._
+
+### Supported engineering practices
+
+- Semantic versioning
+- Automated tests
+- Feature flags
+- Continuous integration
+- Code reviews / pull requests
+- Preview apps
+- Static type systems
+- Observability
+
+## Ship early and often
+
+> _Ship to production as quickly as you possibly can without breaking things. Code in production is money code, and that's the code you're motivated to keep healthy._
+
+### Supported engineering practices
+
+- Feature flags
+- Trunk-based development
+- Automated tests
+- Continuous deployment
+- Timely performance optimization (measure before you optimize)
+- Observability
+
+---
+
+## Additional Resources
+
+No one comes up with engineering values in a vacuum. Over time we pick up ideas from conference talks, blog articles, and coworkers. We try things out and watch them succeed or fail.
+
+In short—we learn.
+
+Here's some conference talks and articles that have been a huge influence on these engineering principles:
+
+- [The Wrong Abstraction](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction) by Sandi Metz
+- [Hot Garbage: Clean Code is Dead](https://www.youtube.com/watch?reload=9&v=-NP_upexPFg) by Michael Chan
+- [A Codebase is an Organism](https://meltingasphalt.com/a-codebase-is-an-organism/) by Kevin Simler
+- [On the Spectrum of Abstraction](https://www.youtube.com/watch?v=mVVNJKv9esE) by Cheng Lou
+- [Figma's Engineering Values](https://www.figma.com/blog/figmas-engineering-values/) by Thomas Wright

--- a/packages/content/writing/friends-dont-let-friends-write-react-boilerplate.md
+++ b/packages/content/writing/friends-dont-let-friends-write-react-boilerplate.md
@@ -1,0 +1,55 @@
+---
+title: Friends Don't Let Friends Write React Boilerplate
+description: If the core of your app could be done on top of a "boilerplate framework", save yourself some time & effort—focus on delivering an awesome user experience.
+date: 2018-02-13
+image:
+  url: 'pies.jpg'
+  alt: Three pies on a table
+---
+
+Have you ever made a pie? If you have, I'm sure you know the amount of detail & precision that goes into that perfect "from-scratch" recipe. Wait a couple minutes too long, and the crust burns. Use too much butter and your pie doesn't have the right texture. Making a creme pie? If you get the measurements wrong your pie could end up as soup (been there, done that. At least it was a tasty mistake).
+
+Makes you wonder why we say "easy as pie", right?
+
+One of the biggest complaints from people about the current JavaScript ecosystem is the state of the tooling. Starting a React project could require 1-3 **days** of setup to get everything working correctly. You've got transpilers, module bundlers, linters, formatters, test runners, etc. Juggling all of these can feel very much like baking a pie &mdash; make one mistake, and you're knee-deep in webpack internals trying to figure out why you can't even get "Hello World" to show up. In many ways it can feel just like baking a pie.
+
+Most of the front-end frameworks have CLIs or boilerplates to alleviate this pain, but conventional wisdom would have you think that writing your own webpack config will result in higher productivity down the road (because after all, you know how it works so you can customize as much as you want). I still see people posting/talking about how good it is to create your own boilerplate.
+
+Most of the time, you don't need a custom boilerplate. Here's why.
+
+## A Couple Disclaimers 🙃
+
+Software engineering is _filled_ with tradeoffs, and the time spent working on tooling is no exception. There may be some cases where spending a bunch of time setting up your project actually does help in the long term. Before we get into details, I wanted to make these two disclaimers, lest anyone draw the wrong conclusions.
+
+- **Learning tooling isn't a waste of time.** But it can be a large barrier to learning something new / delivering faster. There's a lot of tiny choices that you will spend energy on if you spend a lot of time configuring your build chain, and each one of those choices wear you down a little. The good news is that webpack & the other build tools have _amazing docs_ (for the most part), so when you do need to update something, you can usually figure it out on a case-by-case basis.
+- **You might need custom functionality, and that's ok.** I understand that some use cases merit a custom configuration built-from-scratch. But I would also argue that in many cases (especially side projects) these are the exception and not the rule. In addition, you can often build your custom functionality on top of an off-the-shelf solution.
+
+Ok. Now that we've got that out of the way, let's get into the why.
+
+## There's a Lot of Good "Boilerplate Frameworks" Out There
+
+For lots of apps, you can piggy-back off of the myriad of boilerplate & bootstrapping frameworks out there. In the React ecosystem, here's 3 of the most popular.
+
+1. [Create-React-App](https://github.com/facebook/create-react-app) (great for smaller projects & learning React! Also lets you "eject" & customize however you want)
+2. [NextJS](https://github.com/zeit/next.js/) (server-rendering framework with a rich plugin ecosystem)
+3. [Gatsby](https://www.gatsbyjs.org/docs/) (static site generator built on React & GraphQL. Also has a lovely plugin ecosystem).
+
+I use the term "boilerplate frameworks" to describe these type of frameworks/bootstrapping packages since they're not _boilerplates_ in the strictest since of the term. In a boilerplate, you'd typically have access to all of the generated/prepopulated code. However, they allow you to quickly bootstrap an app, fulfilling the initial purpose a boilerplate is meant to serve.
+
+All three of these "boilerplate frameworks" provide opinionated defaults while allowing options for developers to extend functionality. Before you go and spend a bunch of time writing your own config, see if one of these fits what you're looking for (many times it will!). And if you need something one of these doesn't provide, see if there's a plugin (in the case of Gatsby / NextJS, Create-React-App doesn't have plugin functionality). Building on top of one of these solutions or using a plugin with save you **hours** of setup time, meaning you can get your code out to users faster.
+
+## Remember That If You Write Your Own Config, You Will Have to Maintain It.
+
+A lot of these boilerplate frameworks will regularly release updates with security & dependency updates. If your app is built on top of it, you'll get these for free (and fairly painlessly).
+
+Writing your own configuration is a two-edged sword &mdash; you get to update it _any time you want_. You don't have to wait on open source contributions or for the next release. You can change things _today_.
+
+However, when your build pipeline is breaking, you alone have to fix it. When one of your dependencies needs to be updated & that update breaks your build system, you have to dig into the config & _debug your tools_.
+
+Just remember that any time spent debugging your tools is time that you could have spent writing the code that makes your application unique.
+
+## Last Thoughts
+
+A big thanks to [Kyle Holmberg](https://medium.com/@kylemh) for the phrase "Friends Don't Let Friends Write React Boilerplate". He's a super cool developer, also doing frontend web engineering at [AutoGravity](https://www.autogravity.com). Check out his articles, they're super great. 👌🏻
+
+At the end of the day, writing software should be focused on the end users. If that extra time spent on your own config allows you to make things that benefit them, go for it. But if the core of your app could be done on top of a "boilerplate framework", save yourself some time & effort &mdash; focus on delivering an awesome user experience.

--- a/packages/content/writing/function-vs-arrow.md
+++ b/packages/content/writing/function-vs-arrow.md
@@ -1,0 +1,92 @@
+---
+title: '(Personal) code preferences: arrow functions'
+date: 2020-08-20
+tags:
+  - javascript
+  - formatting
+---
+
+> [!WARNING]
+>
+> These represent my opinions at the time of writing. As of right now (June 2024) they're not
+> my current preferences: I'm team `function` keyword because Reasons™.
+>
+> Truly a testament to formatting be aesthetic taste — sometimes tastes change!
+
+Most opinions about code formatting boil down to personal preference.
+
+They're like [Oxford commas](https://www.grammarly.com/blog/what-is-the-oxford-comma-and-why-do-people-care-so-much-about-it/) or essay citations—whether it's "right" or "wrong" depends on the judgment of the style guide you're using.
+
+Styling code consistently is still important. Notably, [it makes scanning and reading code easier](https://benjaminjohnson.me/blog/empathetic-code), especially if that code was written by multiple authors.
+
+But most formatting decisions _are_ based on preference. There isn't an objectively better choice.
+
+As you write code, you'll develop your own preferences about how things should be formatted. And those styling decisions should have _real, valid reasons_ backing them.
+
+Sometimes that reason is "I like the way it looks better", and that's ok.
+
+Sometimes that reason is due to language nuances or edge cases, and that's ok.
+
+But when you work on a team it's important to divide the important formatting decisions from the ones that are purely personal preference. Spending valuable time arguing with your team over small formatting choices is a prime example of ["bikeshedding"](https://en.wiktionary.org/wiki/bikeshedding).
+
+This article is the first in a series that I have lined up in which I'm writing about _my personal preferences_ and the reasoning behind them.
+
+I fully recognize that my way isn't the only valid way. But it's still valuable to capture **_my_** preference and the reasoning behind it.
+
+I'm perfectly fine laying these preferences aside when working within a team. I often have—I'm a firm believer that preferences like this should be delegated to [formatter and linters](https://benjaminjohnson.me/blog/giving-up-control-to-your-tools) instead of taking up human effort.
+
+In this article I'll be sharing my preferences on **_arrow functions and the `function` keyword_**.
+
+---
+
+## Prefer arrow functions to `function`
+
+Instead of writing JavaScript functions using the `function` keyword, just declare them as an arrow function and attach it to a variable.
+
+```js
+// Using `function`
+function add(a, b) {
+	return a + b;
+}
+
+// Using an arrow function
+const add = (a, b) => a + b;
+```
+
+## Why?
+
+I prefer using this syntax because it results in a consistent way to declare functions in a codebase.
+
+Even if you use `function` at the top level, chances are you'll have a number of arrow functions littered around your codebase. For example, inside of `Array.map`, callbacks, and React components' props.
+
+I found that when I used a mix of `function` and arrow functions I had to _decide_ when to use each. Do you do `function` at the top level, arrows everywhere else? `function` when it needs a name, arrow when it's anonymous?
+
+If you're not using `this` they'll mostly likely be equivalent, so it's a purely stylistic decision. There's a few nuances, hold tight for the "Disclaimers" section and we'll get to those.
+
+Defaulting to arrow functions means there's one less decision that I have to make when writing functions.
+
+Having a consistent style for functions also makes refactoring a bit easier. I'm able to pull existing arrow functions into separate files or up to the top level without having to convert them to `function` syntax.
+
+Finally, I like the syntax of the arrow functions a little better. This is purely stylistic—I think the syntax feels a little lighter and draws focus to the functions' input and output.
+
+## Disclaimers
+
+You can't just replace every `function` with an arrow haphazardly. There's a few cases where using an arrow function instead of `function` is required, and vice versa.
+
+If you're using `this`, `arguments`, `super` or `new.target`, it's important which one you use. Arrow functions won't have any of these bound to itself—they'll just look in their surrounding context.
+
+Named arrow functions (`const name = () => {}`) don't [hoist](https://scotch.io/tutorials/understanding-hoisting-in-javascript) to the top of their scope, while `function` does. If you like organizing your code in ["newspaper structure"](https://kentcdodds.com/blog/newspaper-code-structure), then you're much better off using `function`.
+
+Finally, a couple common gripes about arrow functions that I've heard commonly (either in person or on the internet).
+
+- A common argument against arrow functions that they're not actually shorter than using `function`. _Technically_, arrow functions are a few more characters (if you're not using the [implicit return](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)). I still think the syntax is more compact—it neatly fits on a single line in a way that's easy to scan the inputs and outputs.
+
+- Some complain that arrow functions have too many syntax variations. This is a valid complaint—there's a lot of different ways to write arrow functions. But I haven't seen many engineers get tripped up by them. If you're using a tool like Prettier you can just [let it deal with formatting your arrow functions consistently](https://benjaminjohnson.me/blog/giving-up-control-to-your-tools).
+
+- One of the common complaints about arrow functions is that they show up as "Anonymous function" in a stack trace. This is mostly FUD (fear, uncertainty, and doubt). If you use `function` without a name it'll also appear as "Anonymous" as well. If you assign the arrow function to a variable the name shows up just fine.
+
+---
+
+## tl;dr
+
+I prefer using arrow functions over the `function` keyword. Reasoning behind this preference includes: consistent function syntax, ease of refactoring, and compactness.

--- a/packages/content/writing/getting-your-first-software-engineering-job.md
+++ b/packages/content/writing/getting-your-first-software-engineering-job.md
@@ -1,0 +1,65 @@
+---
+title: Getting your first software engineering job
+subtitle:
+date: 2021-09-23
+tags:
+  - career
+  - job-searching
+---
+
+As a musician turned bootcamp-grad turned software engineer, I get asked frequently about my thoughts about breaking into the industry. "What do I need to do to get that ever-elusive first software engineering job?"
+
+To be honest, it's hard to answer. I wish I could say "follow these 4 easy steps and you'll have a job in 4 months", but job searching isn't formulaic. It varies from person to person.
+
+## First, a word of caution about job searching advice
+
+Take other people's tips with a grain of salt — mine included. These are things that worked for **me**, but they may not apply 100% to your situation.
+
+Here's a few aspects to note about my job-search in 2017 that might differ from your experience:
+
+- **The entry-level market has shifted.** Companies expect junior engineers to know a lot more today than I did as a junior engineer. COVID-19 opened up many remote opportunities but it also means global competition for roles.
+- **Demographics and unconscious bias.** I'm a white man, and I entered tech in my mid 20s. Depending on your demographic, my experience may differ from yours. Lots has been said about how we can decrease bias in hiring; that's another article entirely.
+- **Personality.** I'm outgoing and personable. I'm ADHD. These tips worked for me based on my personality. YMMV.
+
+## Stand out from the crowd
+
+Entry-level jobs are scarce, so competition is fierce. If you want to get an interview you need to stand out from the rest.
+
+- **Build real projects.** Your bootcamp portfolio projects probably look identical to other candidates'. Don't put another todo app, timer, or quiz in your portfolio — build something that's uniquely **you**.
+- **Prefer depth over breadth.** Companies expect when they hire entry-level roles that candidates won't know all the technologies in the job description. They're looking for learning trajectory, and you can showcase this much better by knowing one "main thing" inside-out.
+- **Go beyond what your bootcamp taught you.** Did your bootcamp teach unit testing? CI / CD? TypeScript? If you have the time, learning practices adjacent to your "main thing" can help you stand out from the crowd.
+- **Have a good resume and portfolio.** Compare your resume and portfolio to other entry-level candidates. Does yours looks identical? Your portfolio especially, that's your corner of the internet so put your stamp on it.
+- **Learn to write.** Post on LinkedIn and Twitter. Start a blog (use [dev.to](https://dev.to) to get started quickly). Many won't do this extra work, so if you do it's big points in your favor.
+
+## Network as much as possible
+
+This is how I got my first job. I met a guy at a meetup, he introduced me to someone else, and _that_ person introduced me to the recruiter at my first job.
+
+- **Go to meetups.** Go to as many meetups (remote or in-person) as you can fit in your schedule. Meet new people and get to know them. Someone you meet might just hire you!
+- **Join online communities.** Discord and Slack have lots of developer communities. Some are even geared towards entry-level job-seekers! Twitter and LinkedIn are also great ways to get involved in the online developer community.
+- **Be genuine.** Don't just use people for job leads. Build real connections with the people you meet, it's better in the long run. People can sense when you're inauthentic.
+- **Post on social media.** Get on LinkedIn and Twitter. LinkedIn is where the recruiters are, Twitter is where the dev community (at least for JS) is.
+- **Follow. up.** Don't just meet people and expect them to hand you jobs. Message them and follow up. Ask if they can intro you to people that are hiring. Ask what advice they have for job seekers. Don't meet them once and disappear.
+
+## Think of job-searching as a sales funnel
+
+Job searching is sales. When you accept an offer, you are making a business transaction — you agree to trade your time and skills in return for money and benefits.
+
+View the job search as a sales funnel. You only need to close one sale, but when you think of yourself as "the product" and interviews as "leads" you come across as more confident.
+
+## Iterate and improve.
+
+I often hear about bootcamp grads sending out 500+ job applications or failing 100s of interviews on a single job search. And I often wonder whether they are iterating on their process or not.
+
+Assess **where** your job search funnel is breaking down, and then double down in that area. Are you failing to get past the resume screen? Do you bomb technical interviews?
+
+Don't blindly repeat something that's clearly not working. Either work on improving your performance in that area, or look for a way to "change the rules".
+
+For example, use a network-based approach to skip resume screening entirely. Or don't apply at companies that do algorithm challenges if your computer science skills are weak. Or do interview practice with a friend if you struggle answering questions confidently.
+
+You might have to try a few things before you see improvement. But don't let that deter you from tweaking your job search processes to get the results you want.
+
+## Resources
+
+- [The Standout Developer](https://randallkanna.com/the-standout-developer/) by Randall Kanna. I have not read this myself, but it comes highly recommended by some colleagues. I follow Randall on Twitter and she is full of amazing advice for those entering the software industry.
+- [Taylor Desseyn](https://twitter.com/tdesseyn) on Twitter. Taylor's a recruiter and is also full of job search advice for both senior- and entry-level engineers. I've learned tons about how software recruiting works under the hood from popping into his podcast every once in a while.

--- a/packages/content/writing/giving-up-control-to-your-tools.md
+++ b/packages/content/writing/giving-up-control-to-your-tools.md
@@ -1,0 +1,37 @@
+---
+title: Tools like Prettier ask us to give up control
+description: There's nothing wrong about caring about code formatting! Using a formatter requires that we give up fine-grained control and let our tools do the heavy lifting.
+draft: false
+date: 2019-03-01
+image:
+  url: 'plane-controls.jpg'
+  alt: Flight commander tweaks airplane controls
+  by: https://unsplash.com/@byronsterk
+  source: https://unsplash.com
+tags:
+  - formatting
+---
+
+Perhaps you've heard of a tool called [Prettier](https://prettier.io/). If you haven't, Prettier is a code formatter for a variety of languages—JavaScript, TypeScript, CSS, Markdown, GraphQL, and many other languages. It's an amazing tool and I've been a huge fan of having it as a part of my workflow for the past few years.
+
+Working on a project with a formatter installed can be an absolute joy. You simply write code, hit save, and voila! Everything snaps into place and your code is beautifully and consistently formatted across the entire project.
+
+And yet, I've seen a decent amount of pushback when introducing Prettier to a team. I've done this a few times over the past few years, and adoption often been initially met with reluctance. Then, after we start using it Prettier becomes one of the team's favorite tools.
+
+I think one of the main reasons that tools like Prettier receive pushback is simply because it—not developers—formats the code. It remains opinionated by not providing a ton of configuration options. So the code might be formatted in a way that _you_ initially "dislike". Even though the code works 100% the same as it did pre-formatting, it's not the way _you_ "would have formatted it". Perhaps it's the way it breaks lines or handles ternary expressions or you didn't like it adding/removing semicolons.
+
+Prettier doesn't hide the fact that it's opinionated about formatting code. It's chosen description is "An opinionated code formatter". Opinionated tools always comes with an ask. They say, "Leave the formatting to me—don't worry, I've got this."
+
+When we adopt opinionated tools like Prettier we do lose something—fine-grained control over how our code looks. But what we gain in return can make the loss 100% worth it.
+
+When we give control of formatting over to our tools we can eliminate formatting from our mental checklist. I didn't realize how much time and effort I spent deciding whether a function should be broken into a single line vs. multiple lines, trying to hunt down missing semicolons, or other miscellaneous formatting decisions. I sincerely wanted to do the "cleanest" formatting for my code but I'd go back and forth on what formats I liked. Although each of these amount to small decisions, they add up over the course of a day. If we can cut out an entire _category_ of decisions from our workflow, we save more decision-making power for stuff that can't be automated, like variable names, creating good interfaces, and future maintainability.
+
+When we give control of formatting over to our tools we also eliminate an entire class of pull request (PR) comments. Seeing a PR with 50 comments of "semicolon here" or "please break into multiple lines" isn't enjoyable for the reviewer _or_ the author). We can set the PR author up for success if we simply add a formatter to our project workflow—whatever the formatter does is the "right way" for the project. This scopes the conversation about formatting to a single decision—choosing which formatter to add and how to configure it. Instead of spending precious time and energy fighting over style, PR reviewers can focus on the maintainability of the new code and how it fits within the larger ecosystem of the codebase.
+
+When we give control of formatting over to our tools we make our project more welcoming to newcomers. Whether it's someone who's just started learning how to code or a seasoned veteran juggling 3-4 different projects (each with their own formatting requirements), having tools guarantee that every commit and PR is formatted correctly helps these newcomers get up to speed quickly and start contributing value.
+
+---
+
+Tools like Prettier ask us to loosen our grip on code formatting and styling. Many of us are passionate about the code we write—and there's nothing wrong about that! However, this passion often results in us holding on tightly to our idea of what "looks good" or "looks bad". Using a formatter for any team project turns this conversation about style into a one-time decision—which formatter shall you choose, and how shall you configure it.
+
+What about you? Have you encountered pushback when introducing formatters into a codebase? Have you pushed back yourself? I'd love to hear any thoughts you have about what happens when we let our tools take control. If you want you can reach out to me on [Twitter](https://twitter.com/benjamminj) and let me know what you think!

--- a/packages/content/writing/how-css-works-creating-layers-with-z-index.md
+++ b/packages/content/writing/how-css-works-creating-layers-with-z-index.md
@@ -1,0 +1,12 @@
+---
+title: 'How CSS works: Creating layers with z-index'
+description: 'This is the final article of my "How CSS Works" series, where I look into one of the most misunderstood parts of CSS: z-index.'
+
+date: 2018-07-02
+publisher: LogRocket
+link: https://blog.logrocket.com/how-css-works-creating-layers-with-z-index-6a20afe1550e/
+tags:
+  - css
+---
+
+This is the final article of my "How CSS Works" series, where I look into one of the most misunderstood parts of CSS—z-index

--- a/packages/content/writing/how-css-works-parsing-and-painting-in-the-critical-rendering-path.md
+++ b/packages/content/writing/how-css-works-parsing-and-painting-in-the-critical-rendering-path.md
@@ -1,0 +1,12 @@
+---
+title: 'How CSS works: Parsing & painting CSS in the critical rendering path'
+description: Dive into the critical rendering path and see what happens to the CSS that we write.
+
+date: 2018-04-10
+publisher: LogRocket
+link: https://blog.logrocket.com/how-css-works-parsing-painting-css-in-the-critical-rendering-path-b3ee290762d3/
+tags:
+  - css
+---
+
+This is the first article of my "How CSS works" series, in which I explore CSS fundamentals. In this article I dive into the "critical rendering path" and how the CSS that we write gets turned from code into pixels on the screen.

--- a/packages/content/writing/how-css-works-understanding-the-cascade.md
+++ b/packages/content/writing/how-css-works-understanding-the-cascade.md
@@ -1,0 +1,12 @@
+---
+title: 'How CSS works: Understanding the cascade'
+description: When we peel back the layers we see that the cascade isn't as confusing as it seems
+
+publisher: LogRocket
+date: 2018-05-29
+link: https://blog.logrocket.com/how-css-works-understanding-the-cascade-d181cd89a4d8/
+tags:
+  - css
+---
+
+This is the second article of my "How CSS Works" series, in which I dive into the internals of the CSS cascade algorithm and CSS specificity.

--- a/packages/content/writing/how-tailwindcss-converted-me.md
+++ b/packages/content/writing/how-tailwindcss-converted-me.md
@@ -1,0 +1,201 @@
+---
+title: How TailwindCSS converted me
+subtitle: 'Slowly but surely, utility-first CSS won me over.'
+date: 2020-12-17
+tags:
+  - css
+  - front-end
+---
+
+I'm _surprised_ I like [TailwindCSS](https://tailwindcss.com/). I tried it a couple years ago (pre-v1) and I remember that I couldn't stand this whole "utility-first" CSS thing.
+
+Instead, I dove headfirst into CSS-in-JS, trying out `styled-components`, `emotion`, and a few other libraries.
+
+For the past couple years, `emotion` has been easily my go-to approach for CSS. I've built some large apps using it, and I think it's fantastic if you're going with CSS-in-JS.
+
+However, I kept seeing all this Tailwind hype on Twitter. I had some people mention it on my [Twitch stream](https://www.twitch.tv/benjamindjohnson) as well as some coworkers talking about it. A couple months ago I figured it was time to give it another shot.
+
+I think Tailwind has unseated CSS-in-JS (and `emotion`) as my go-to CSS solution. I was pretty skeptical but it's finally converted me over. 🎉
+
+Here's some of my thoughts on _why_ I'm choosing Tailwind these days and why I'm now choosing it over CSS-in-JS.
+
+---
+
+## tl;dr ⏱
+
+Before we deep-dive, here's an executive summary. If you're pitching Tailwind to your team I would start here:
+
+- **Colocation of styles and markup.** While this feels like it violates "separation of concerns", it's views the _component_ as the unit of composition in front-end apps.
+- **Less naming fatigue.** Not being forced to name containers and wrapper frees you up to spend energy on more important problems.
+- **No JS runtime.** Save some kb of JS and send down regular ol' CSS instead. Don't forget to purge the unused Tailwind classes though!
+- **Scales better than you'd think.** Having things inline feels like a recipe for disaster, but Tailwind delivers on its promises if you give it a shot.
+- **Constraint-driven.** Having a design system with constraints built into it means that using Tailwind will often lead to more consistent, cleaner UIs. Especially if you're not a designer.
+
+---
+
+## The tradeoffs you make with Tailwind
+
+Since I was a skeptic about utility-first CSS, I'm going to start with the reasons I _didn't_ like Tailwind, and what's changed.
+
+Hopefully these line up with your concerns about Tailwind if you're on the fence. _(Or if you're advocating using Tailwind on your team and you're having struggles convincing team members.)_
+
+### wHaT aBOut sEpArAtIOn oF cOnCErns?
+
+When I learned programming, I was taught that markup (HTML), styles (CSS), and functionality (JS) should be split into separate files.
+
+After building some larger (and more complex) applications, I don't think "concerns" in front-end apps always map nicely to HTML, CSS, and JS files. Especially if you're using a framework.
+
+In React we put HTML in our JS files ([JSX](https://reactjs.org/docs/introducing-jsx.html)). [Vue's single-file components](https://v3.vuejs.org/guide/single-file-component.html#single-file-components) put HTML/CSS/JS in one `.vue` file.
+
+In modern web apps I think the _component itself_ is the "concern" we want to separate. It's not the styles vs the JS vs markup—they all work together to make up the self-contained component.
+
+As I've reflected on components being self-contained, I've grown more and more open to having styling directly in my markup. _(I've actually been doing this for a while via `emotion`'s `css` prop.)_
+
+Adam Wathan (Tailwind's creator) also has a fantastic article on [separation of concerns and utility CSS](https://adamwathan.me/css-utility-classes-and-separation-of-concerns/). If this is your main roadblock to trying out Tailwind I'd highly recommend giving it a read.
+
+### Ugly markup
+
+Another thing that I originally _hated_ with Tailwind was the explosion of classes into my HTML.
+
+It can be a bit jarring seeing that list of classes the first time you have to do some complex styling.
+
+```html
+<a
+	href="https://example.com"
+	className="inline-block text-xl font-medium text-black no-underline dark:text-white"
+>
+	<span className="lowercase">Link text</span>
+</a>
+```
+
+And unlike CSS-in-JS, you can't statically type the fields with TypeScript. Splitting the string of classes into multiple lines is also less than ideal.
+
+I'll admit, it took me a while to acclimate to this. However, I now think the single string of classes (in most cases) to be less messy than using a CSS-in-JS `css` prop. Tailwind's classes all fit into a single (albeit long) line while the `css` prop styles will do a single line per rule.
+
+And while having a `styled-component` results in less _markup code_, this comes with its own tradeoffs (you lose colocation of styles/markup to trim down lines of markup)
+
+### Big CSS file size
+
+When I had originally tried Tailwind the file size of the bundled CSS was a big concern. If I remember correctly, `purgecss` was not bundled with Tailwind so you had to set it up separately.
+
+> _If you're not familiar with `purgecss`, it's a `postcss` plugin that removes any CSS that isn't used._
+
+Now that `purgecss` comes built-in to `tailwind.config.js` keeping production files small is easy-peasy.
+
+The key thing to remember about `purgecss` is that it operates by finding string matches of classes in your code. This means that you can't do dynamic JS to build Tailwind classes since `purgecss` won't match them and will mark them for removal.
+
+Which brings me to the next trade-off of Tailwind...
+
+### Not as dynamic as CSS-in-JS
+
+Simply put, Tailwind is nowhere near as dynamic as CSS-in-JS. And that's a good thing.
+
+With CSS-in-JS, you have the full power of JavaScript (or TypeScript) as your preprocessor. Turns out, this is a double-edged sword.
+
+JS as a preprocessor can let you dynamically style based on data, create elegant "DRY" mixins, and get static typing.
+
+The thing is, a lot of times we don't need that much power. We just need to flip a couple styles based on our button is `primary` or `secondary`.
+
+I've found I can get 90% of the dynamic styles I need by conditionally applying classes with [`clsx`](https://github.com/lukeed/clsx) (or [`classnames`](https://github.com/JedWatson/classnames)). For the other 10%, a combination of inline styles, custom CSS, and CSS variables is enough.
+
+If you have super dynamic styles, you don't _have_ to exclude CSS-in-JS to use Tailwind. You can use both in an app, or use the [`tailwind-babel-macro`](https://github.com/bradlc/babel-plugin-tailwind-components) to generate CSS-in-JS styles.
+
+### Good for prototyping and small projects, but it won't scale.
+
+Lastly, my common reply whenever Tailwind got brought up used to be "I think it looks _interesting_, but I wouldn't pick it if the project needs to _scale_".
+
+I thought it was only a good tool for prototyping and smaller apps.
+
+**I was wrong.**
+
+Now that I've built a few apps with Tailwind, I think I can say that it has the qualities I'd look for when searching for a "robust" styling approach.
+
+In fact, I'd say that Tailwind not only makes scaling your styles _possible_, it might even make it _simpler_.
+
+_I couldn't find a list of companies using Tailwind at the time of writing. But check any comments section, Hacker News, Twitter, etc and you'll find anecdotal evidence of people shipping production-grade apps with it._
+
+## Some additional benefits of Tailwind
+
+Now that we've gone through my past blockers to using Tailwind, I wanna look at a couple extra benefits I think using Tailwind offers.
+
+### Colocation of styles & markup
+
+We already touched on this a little bit when talking about "separation of concerns" but it bears repeating. Having styles and markup in a single file initially _sounds_ bad, but it carries numerous benefits:
+
+- Deleting HTML (or JSX) automatically deletes its associated CSS.
+- Less nasty import paths (bye, bye, `../../../../`)
+- Smaller, more manageable directory structure.
+
+Note that colocation of styles and markup is possible in CSS-in-JS via thins like `emotion`'s `css` prop and `theme-ui`'s `sx` prop.
+
+I'm not the first to extol the pluses of colocation—check out [this article by Kent C. Dodds](https://kentcdodds.com/blog/colocation) on how colocation can help software projects stay maintainable.
+
+### Less naming fatigue
+
+Naming things is hard. After all, it _is_ one of the ["two hard problems"](https://martinfowler.com/bliki/TwoHardThings.html) in software development.
+
+It's critical that we learn to give things meaningful names when we're building software projects.
+
+But we don't have to name **every. single. thing.** We can pick and choose our battles.
+
+I experienced this naming fatigue when using CSS-in-JS libraries like `styled-components` as well as in raw CSS using [BEM](https://css-tricks.com/bem-101/) naming conventions.
+
+The problem is that you have to create a meaningful name in order to apply styles to any HTML tag. This adds significant mental overhead—after all, there's only so many variations of `Container` and `Wrapper` out there. 😅
+
+I'm not saying that you never name styles—you'll probably want to abstract things into components and give them meaningful names. But it's liberating to not be _required_ to come up with a name when all you want is a little `padding` on a `div`.
+
+### Built-in design system
+
+Tailwind's approach to CSS centers largely around _design systems_ and generating _design system tokens_. Tailwind sets up a design system and corresponding CSS classes for you out of the gate. However if you (or your designer) need custom values you can customize the generated CSS via `tailwind.config.js`
+
+For example, instead of allowing you to pick any pixel (or `rem`!) value for margin, Tailwind sets up classes like `.m-0` (`0`), `.m-4` (`1rem`), `.m-6` (`1.5rem`). Each number on the `m` scale corresponds to a predetermined value.
+
+While it seems like having full control over the pixel values would let you achieve pixel perfection, it turns out having _some constraints_ forces you to choose the nearest value from your design system. This generally leads to a more unified design.
+
+This _can_ be done in CSS-in-JS or raw CSS/SCSS, but you'll have to create the design system tokens yourself, which can take a good deal of time and effort (`theme-ui` does create tokens for you by default). You'll also have to enforce design system in usage in every PR to make sure that people don't sneak hard-coded pixel values in.
+
+### Framework agnostic
+
+As a whole, CSS-in-JS tends to favor the React ecosystem. While there are a few framework agnostic CSS-in-JS libraries (`emotion` included), most are geared towards the React community.
+
+For example, `styled-components` only works with React (to my knowledge), and I'd consider `emotion` to be React-first (most of the documentation assumes you're using JSX).
+
+In contrast, Tailwind is built on top of PostCSS and integrates seamlessly into any front-end project. It's nice knowing that knowledge of this tool can be reused in a project using Vue, Svelte, Angular, or even raw HTML.
+
+### Less build setup
+
+Tailwind definitely involves _some_ build setup, but much less than a lot of CSS-in-JS libraries.
+
+If you're building a moderately large project, the CSS won't be the _only_ thing you have to setup. Chances are you'll have to integrate your solution along with stuff like TypeScript, Babel, ESLint, Jest, and server-rendering.
+
+Getting all of these to play nice in the sandbox can make you tear your hair out. I've spent multiple _days_ getting a CSS-in-JS setup working properly with full server-rendering, TypeScript, ESLint, and JEst support. It's not pleasant.
+
+Although Tailwind requires a configuration file, they make it easy to get up and running. You can run `npx tailwind init` and they'll generate a config file with all of the defaults applied! 🎉
+
+This lets you spend less time setting up your project and more time building your project.
+
+### No runtime JavaScript
+
+This is a big win for Tailwind over CSS-in-JS. Since Tailwind is a CSS utility framework, it doesn't add any JS to your production bundle.
+
+In contrast we have CSS-in-JS which ships with a runtime to parse the style objects into valid CSS, generate classes, and insert those into the `head` of the document.
+
+`@emotion/react`'s runtime is about 10kb (gzip + min) and `styled-components` ships with about 12kb of JS (gzip + min). And that's before you write any of your own code.
+
+Tailwind doesn't ship any runtime JS, which creates a little more space on the main thread for everything else in your app as well as faster load times for your users.
+
+> ⚠️ _If you forget to use `purgecss` you might accidentally send **the entire Tailwind CSS** in your production code. This would actually be worse since Tailwind v2 is about 290kb gzipped! [You can read more about purging CSS here](https://tailwindcss.com/docs/optimizing-for-production)_.
+
+---
+
+## Some closing thoughts
+
+Tailwind is far from being a **perfect** CSS solution, but I think it's a **good** one. Who knows? I might be writing another post like this about some other technology in a year or so. 😅
+
+That said, Tailwind is controversial in the front-end community because it throws so much "conventional wisdom" out the door. And yet people using Tailwind are extremely satisfied with it—head over to any public forum and you'll see people gushing over Tailwind.
+
+There is no silver bullet when it comes to software tools. There's only pragmatically evaluating the pros and cons of each tool, and explicitly choosing the tradeoffs that seem best for your given use-case.
+
+Right now, Tailwind is one of those tools—I like the tradeoffs it makes and think it will prove extremely useful as I continue to build web apps.
+
+Feel free to reach out with any feedback or comments! You can find me on [Twitter](https://twitter.com/benjamminj) and [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/). If you see a typo or if there's a significant mistake in what I've written, please open a [PR](https://github.com/benjamminj/portfolio/tree/main/writing) to edit this article. Thanks for reading!

--- a/packages/content/writing/learning-a-new-codebase.md
+++ b/packages/content/writing/learning-a-new-codebase.md
@@ -1,0 +1,43 @@
+---
+title: 'Learning a New Codebase: The Good, The Bad, and The Ugly'
+description: If getting up to speed with a codebase of thousands and thousands of lines sounds intimidating, remember that it is a long process that greatly pays off.
+date: 2017-08-28
+---
+
+At one point or another — whether you’re a seasoned pro or just getting started — you’re going to have to learn a new codebase. It’s always easier to know the code inside and out when you’ve crafted every line yourself, but what about when you’re hopping into a new project, potentially with thousands of lines? You want to get up to speed quickly and start providing real contributions, but how can you do that if you don’t understand how the application works?
+
+I’ll be honest, I’m no seasoned veteran, but I have had to grok a couple large codebases in the past year that I’ve spent on this programming journey. To top it off, I just started a new job with a few new codebases, so this is all fresh in my head.
+
+## 1. Read, Read, Read
+
+The fact is simple: to understand what the code in your codebase is doing, you are going to have to read it.
+
+Read everything — unit tests, documentation, and the code itself. Read it slowly, line by line, and figure out what it’s doing. Read as much of it as you can, as often as you can.
+
+Just by reading the code, you’ll automatically start to see a few things—styling, naming conventions, organizational structures, etc. Pretty soon you’ll also have a much better understanding of what the code actually does, making it way easier for you to make changes. But more on that later.
+
+Oftentimes, codebases are extremely large—over a few thousand lines—and you simply won’t have the luxury of sitting down to read the whole codebase from start to finish. I’ve only been able to do this on one occasion, but the application was about 300 lines of code.
+
+Instead of trying to sit down for a full reading, choose a starting place (usually whatever you’re working on at the moment) and figure out how it works internally. Then follow that single module through the rest of the application, seeing where and how it is used. If the codebase is broken up into understandable chunks, understanding how a single module works will greatly increase you knowledge of the whole application.
+
+## 2. Ask questions
+
+However, simply reading code isn’t enough. Ultimately, you have to understand the code, and sometimes this mean asking questions.
+
+Ask yourself questions when you’re reading. Many times, you can find the answers to your questions by either reading more or doing a little online research. If after that you don’t understand something, don’t be afraid to ask the engineers that wrote it.
+
+Ideally many questions will be answered in the code’s documentation, but sometimes this isn’t the case. When there isn’t documentation or comments to explain unclear code, you will have to either find the answers yourself or simply ask for them.
+
+## 3. Don’t be afraid to make changes.
+
+One of the best ways to find out stuff works is to break things. You make a change, perhaps a new feature, perhaps refactoring some code, and you break the application, or now all of the tests are failing. That’s good — now you have a better understanding of how that section of code works.
+
+This strategy only works to some degree. Obviously you can’t just break things or make changes at random, simply hoping that they’ll work. However, if your team has a peer review system of CI/unit tests, you can make changes confidently, knowing that when you break stuff it will never make it to production code.
+
+Life is too short to be paralyzed by fear of breaking things. Rather than being afraid of error messages, understand that each time you break something is an chance to learn something new about how the codebase works. Once you’ve fixed it (even if that’s just rolling back your changes), finding our why/how you broke the application is crucial to understanding how that specific part of the code interacts with the entire codebase.
+
+## Conclusion
+
+If getting up to speed with a codebase of thousands and thousands of lines sounds intimidating to you, just remember that it is a long process with great payoff.
+
+To some degree, it’s a process that you never complete, since the codebase changes rapidly as you and your team work on it. There will always be new code written by other developers that you need to read and understand. That’s part of the thrill of working in software development — the codebase is a living, changing organism, and you are always learning new things about it.

--- a/packages/content/writing/loading-dots-icon.md
+++ b/packages/content/writing/loading-dots-icon.md
@@ -1,0 +1,118 @@
+---
+title: Loading dots icon
+description: AKA "thinking bubbles". Created with React, Tailwind, and TS
+date: 2022-04-10
+tags:
+  - recipes
+  - react
+  - typescript
+  - front-end
+  - css
+---
+
+```tsx
+// loading-dots.tsx
+
+// Note: these types can commonly go in a central file of utility types for
+// all SVG icons, or can be baked into your component lib if you've made one for your
+// icons
+export type IconSize = 'sm' | 'base' | 'lg';
+
+export type SvgIconProps = {
+	size?: IconSize;
+};
+
+const iconSizeClasses = {
+	sm: 'h-4',
+	base: 'h-6',
+	lg: 'h-6'
+};
+
+export const LoadingDots = ({
+	size = 'base',
+	title = 'Loading'
+}: SvgIconProps & { title?: string }) => {
+	const className = iconSizeClasses[size];
+	return (
+		<svg viewBox="0 0 60 30" xmlns="http://www.w3.org/2000/svg" className={className} role="img">
+			<title>{title}</title>
+			<g className="fill-current">
+				<circle
+					cx="12"
+					cy="15"
+					r="6"
+					className="animate-pulse animation-delay-[0ms] animation-duration-[1.5s] opacity-0"
+				/>
+				<circle
+					cx="30"
+					cy="15"
+					r="6"
+					className="animate-pulse animation-delay-[200ms] animation-duration-[1.5s] opacity-0"
+				/>
+				<circle
+					cx="48"
+					cy="15"
+					r="6"
+					className="animate-pulse animation-delay-[400ms] animation-duration-[1.5s] opacity-0"
+				/>
+			</g>
+		</svg>
+	);
+};
+```
+
+And in order to get those `animation-duration` and `animation-delay` classes, we need to do a tiny bit of tinkering with the `tailwind.config.js`
+
+```js
+// tailwind.config.js
+
+const plugin = require('tailwindcss/plugin');
+
+module.exports = {
+	// theme, content, etc.
+	plugins: [
+		plugin(({ addUtilities, matchUtilities, theme }) => {
+			matchUtilities(
+				{
+					'animation-duration': (value) => ({
+						animationDuration: value
+					})
+				},
+				{ values: theme('transitionDuration') }
+			);
+
+			matchUtilities(
+				{
+					'animation-delay': (value) => ({
+						animationDelay: value
+					})
+				},
+				{ values: theme('transitionDelay') }
+			);
+		})
+	]
+};
+```
+
+## Context
+
+This component allows you to make the fancy "loading dots" or "thinking bubbles" component. I commonly find myself reaching for an icon like this, yet it's one that's not as common in icon libraries.
+
+I'm often been using [TailwindCSS](https://tailwindcss.com/) to style my apps, so I included Tailwind classes in this snippet instead of the raw CSS.
+
+## How it works
+
+With a bit of custom SVG we can create this icon from scratch without having to whip out a design tool. Since this icon does not have complex paths or lines, we can use the SVG `circle` element to get our three dots, and the rest is fiddling with the `viewBox`, `cx`, `cy`, and `r` to get the circles exactly where we'd like them.
+
+In order for screen readers to read the icon properly, we also need to add a `title` attribute. Since this is commonly used as a standalone loading indicator `title` is included in the icon props.
+
+## Usage
+
+```tsx
+// All the HTML attributes permitted on `button`, as well as a `loading` flag
+type ButtonProps = JSX.IntrinsicElements['button'] & { loading?: boolean };
+
+const Button = ({ loading = false }: ButtonProps) => {
+	return <button>{loading ? <LoadingDots /> : 'Save'}</button>;
+};
+```

--- a/packages/content/writing/lodash-set-vanilla-js.md
+++ b/packages/content/writing/lodash-set-vanilla-js.md
@@ -1,0 +1,94 @@
+---
+title: Lodash `set` in raw JavaScript
+subtitle: Skip the extra dependency and use this small utility from scratch.
+date: 2022-03-17
+tags:
+  - from-scratch
+  - typescript
+  - javascript
+  - recipes
+---
+
+```tsx
+/**
+ * This is a replacement for lodash _.set(), it contains core functionality but
+ * perhaps skips some edge cases.
+ */
+export const set = <T extends Record<string, unknown> = Record<string, unknown>>(
+	obj: Record<keyof T, unknown>,
+	path: string | string[],
+	value: unknown
+): T => {
+	// Contains all characters that are not `.`, `[`, or `]`
+	const validPathCharactersRegex = /([^[.\]])+/g;
+	const pathArray = Array.isArray(path) ? path : path.match(validPathCharactersRegex);
+
+	if (!pathArray) return obj;
+
+	let nestedObj = obj;
+	for (let i = 0; i < pathArray.length; i++) {
+		let key: string | number = pathArray[i];
+
+		// First, set the item to an object/array, if it's not the last we want
+		// to make a nested path.
+		if (nestedObj[key] === undefined) {
+			const isIndex = isNaN(Number(pathArray[i + 1]));
+			nestedObj[key as keyof T] = isIndex ? {} : [];
+		}
+
+		// If it's the last in the list, set the item to the value
+		if (i === pathArray.length - 1) {
+			nestedObj[key as keyof T] = value;
+		}
+
+		nestedObj = nestedObj[key];
+	}
+
+	return obj;
+};
+```
+
+## Context
+
+`set` is a drop-in replacement for Lodash's `_.set` method. It allows you to set the value at a given path. If the path doesn't exist yet, it also creates the path for you! (woohoo, no `undefined` exceptions!).
+
+I find many of my projects only use a few Lodash methods. Sometimes it's just better to just copy them over into the codbase "from scratch" (and save a dependency in the process!). While this `set` method doesn't cover _all_ the edge cases Lodash does, it covers the primary workflows.
+
+This snippet of `set` also is ~200 bytes, so it's super lightweight 😅
+
+## Usage
+
+```tsx
+import { set } from './set';
+
+const obj = { a: 1 };
+
+// set a path deep in the object
+set(obj, 'b.c.d', 3);
+console.log(obj.b.c.d); // 3
+
+// you can also set array items
+set(obj, 'b.e[0].f', 4);
+console.log(obj.b.e); // [{ f: 4 }]
+```
+
+## Tests
+
+```ts
+import { set } from './set';
+
+test('should allow setting nested paths', () => {
+	const obj = {};
+	set(obj, 'a.b.c', 1);
+	// @ts-expect-error
+	expect(obj.a.b.c).toEqual(1);
+});
+
+test('should allow setting nested array paths', () => {
+	const obj = {};
+	set(obj, 'a.b[0].c', 1);
+	set(obj, 'a.b[1].c', 2);
+	// @ts-expect-error
+	expect(obj.a.b).toEqual([{ c: 1 }, { c: 2 }]);
+});
+```

--- a/packages/content/writing/march-2022-update.md
+++ b/packages/content/writing/march-2022-update.md
@@ -1,0 +1,27 @@
+---
+title: March 2022 Update
+date: 2022-04-01
+tags:
+  - updates
+  - writing
+---
+
+## Trying something new 🧪
+
+I'm gonna try writing some of these smaller updates on a (hopefully) monthly basis. With new responsibilities (more on that coming soon!) I've found that I have less and less time to write here.
+
+That said, I'm not gonna beat myself up if I miss an update. Sometimes life happens and the website won't be updated, and that's ok.
+
+## New family member 👶
+
+![Ian Johnson](https://user-images.githubusercontent.com/20060118/161328996-a5ab7cb7-4ab6-467d-91b5-17506d239f8b.JPG)
+
+On March 19 my wife and I welcomed Ian to our family! We love this little guy so much and have cherished each sleep-deprived moment since his arrival.
+
+I've been on parental leave since, and am _loving it_. I'm incredibly grateful to [Panther Labs](https://panther.com) for this time to bond with my family and adjust to my new job as Dad.
+
+## Miscellaneous updates 🤓
+
+- Been playing with [Remix](https://remix.run/) quite a bit lately, and loving it. I'm especially fond of the focus on _fundamentals_ and _simplicity_. It certainly feels like a breath of fresh air.
+- Just finished reading [Kill it with Fire](https://nostarch.com/kill-it-fire) by Marianne Bellotti. I highly recommend it, especially if you work on any software that needs to live more than a couple months.
+- Per the above announcement, most of my energy has gone into learning my new role as Dad, and adjusting to life as a new parent 💕

--- a/packages/content/writing/mocking-fetch.md
+++ b/packages/content/writing/mocking-fetch.md
@@ -1,0 +1,238 @@
+---
+title: Mocking the fetch API with Jest
+description: Why should we mock the network? We'll take a look at why it's important to mock window.fetch and a couple methods we can use in our test suites.
+draft: false
+date: 2019-04-26
+lastUpdated: 2020-12-30T00:00:00.000Z
+image:
+  url: 'blue-paint-swirls.jpg'
+  alt: 'Abstract swirling colors of blue and red'
+tags:
+  - testing
+  - jest
+  - javascript
+---
+
+> [!WARNING]
+>
+> **Note:** I've left the bulk of this article untouched for posterity, but I wouldn't recommend mocking
+> `fetch` using this method anymore (as of June 2024).
+>
+> Personally, I'd go with [mock-service-worker](https://mswjs.io/) if you need to mock network requests in your unit tests.
+
+In this tutorial we are going to look at mocking out network calls in unit tests. Specifically we are going to dive into mocking the `window.fetch` API. If you're unfamiliar with the `fetch` API, it's a browser API that allows you to make network requests for data (you can also read more about it [here](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)). We'll look at _why_ we would want to mock `fetch` in our unit tests, as well as a few different mocking approaches that we can use.
+
+## Why would we want to mock out network calls?
+
+Before we go straight into mocking the `fetch` API, I think it's important that we take a step back and ask ourselves _why_ we would want to mock it. Otherwise, we'll just know how to write the mock instead of actually knowing what value it provides.
+
+One of the main reasons we have for mocking `fetch` is that this is how our app interacts with the outside world. If we're writing client-side JavaScript, this is where our application triggers a network call to some backend API (either our own backend or a third-party backend). And if we're writing server-side JavaScript (using `fetch` via a package like `node-fetch`) this is where our server talks to _another_ server outside of itself.
+
+If we simply let `fetch` do its thing without mocking it at all, we introduce the possibility of flakiness into our tests. A unit test would be considered to be _flaky_ if it _does not always produce the exact same output given the same inputs_. The following example will always produce the same output.
+
+```js
+function add(a, b) {
+	return a + b;
+}
+
+// This is the test for the `add` function
+describe('add', () => {
+	test('adds 2 numbers', () => {
+		expect(add(1, 2)).toEqual(3);
+	});
+});
+```
+
+However, when testing code that uses `fetch` there's a lot of factors that can make our test fail——and many of them are not directly related to input of the function. What happens if your computer is disconnected from the internet? What happens to your test suite if you're working on an airplane (and you _didn't_ pay for in-flight wifi)? What happens when that third-party API is down and you can't even merge a pull request because all of your tests are failing?
+
+Secondly, mocking `fetch` allows us to exert fine-grained control over what data our app receives "from the API".
+
+If we're able to replace all network calls with reliable data, this also means that we can replicate scenarios in our testing environments that would be difficult to reproduce if we were hitting a real API. While it might be difficult to reproduce what happens on the client-side when the API returns 500 errors (without actually breaking the API), if we're mocking out the responses we can easily create a test to cover that edge case.
+
+## Mocking the fetch API
+
+So, now that we know _why_ we would want to mock out `fetch`, the next question is _how_ do we do it? There's a few ways that we'll explore. Each one has unique tradeoffs——it's difficult to say whether one is "better" or "worse" since they both achieve the same effect.
+
+### Method #1: Replace the global `fetch` with our mocked `fetch`
+
+The first way that we can go about mocking `fetch` is to actually _replace the `global.fetch`_ function with our own mocked `fetch` (If you're not familiar with `global`, it essentially behaves the exact same as `window`, except that it works in both the browser _and_ Node. That way you don't have to change where you're getting `fetch` from per environment. You can read more about `global` [here](TK link)).
+
+It's not usually a good idea to replace things on the `global`/`window` object! True to its name, the stuff on `global` will have effects on _your entire application_. Every time that you add stuff to the `global` namespace you're adding complexity to the app itself and risking the chance of naming collisions and side-effects.
+
+However, in the testing environment we can get away with replacing `global.fetch` with our own mocked version——we just have to make sure that after our tests run we clean our mocks up correctly. That way we don't accidentally replace `fetch` for a separate test suite (which might call a different API with a different response).
+
+Here's what it would look like to mock `global.fetch` by replacing it entirely.
+
+```js
+// This is the function we'll be testing
+async function withFetch() {
+	const res = await fetch('https://jsonplaceholder.typicode.com/posts');
+	const json = await res.json();
+
+	return json;
+}
+
+// This is the section where we mock `fetch`
+const unmockedFetch = global.fetch;
+
+beforeAll(() => {
+	global.fetch = () =>
+		Promise.resolve({
+			json: () => Promise.resolve([]),
+		});
+});
+
+afterAll(() => {
+	global.fetch = unmockedFetch;
+});
+
+// This is actual testing suite
+describe('withFetch', () => {
+	test('works', async () => {
+		const json = await withFetch();
+		expect(Array.isArray(json)).toEqual(true);
+		expect(json.length).toEqual(0);
+	});
+});
+```
+
+Let's walk through this example! 😅
+
+First, we have the actual `withFetch` function that we'll be testing. Usually this would live in a separate file from your unit test, but for the sake of keeping the example short I've just included it inline with the tests. `withFetch` doesn't really do much——underneath the hood it hits the [placeholderjson](https://jsonplaceholder.typicode.com/) API and grabs an array of posts. This array in the API response is 100 posts long and each post just contains dummy text.
+
+Next, let's skip over the mocking portion for a sec and take a look at the unit test itself. The unit test calls the `withFetch` function and waits for it to resolve (since it's an `async` function we use `await` to pause execution until `withFetch` resolves). Then we assert that the returned data is an array of 0 items. If we actually hit the [placeholderjson](https://jsonplaceholder.typicode.com/) API and it returns 100 items this test is guaranteed to fail!
+
+This test is setup to make sure that we actually mock `fetch`. In order to make our test pass we will have to replace the `fetch` with our own response of 0 items.
+
+Finally, we have the mock for `global.fetch`. As a quick refresher, the mocking code consists of three parts:
+
+```js
+// Part 1
+const unmockedFetch = global.fetch;
+
+// Part 2
+beforeAll(() => {
+	global.fetch = () =>
+		Promise.resolve({
+			json: () => Promise.resolve([]),
+		});
+});
+
+// Part 3
+afterAll(() => {
+	global.fetch = unmockedFetch;
+});
+```
+
+In the first part we store a reference to the _actual function_ for `global.fetch`. Since we'll be mocking `global.fetch` out at a later point we want to keep this reference around so that we can use it to cleanup our mock after we're done testing.
+
+The second part consists of the actual `fetch` mock. The important thing to note is that the mocked `fetch` API _must be API-compatible_ with the real `fetch` API. `fetch` returns a resolved `Promise` with a `json` method (which also returns a `Promise` with the JSON data). So we need to do the same thing inside our mock. In order to mock something effectively you must understand the API (or at least the portion that you're using).
+
+You don't need to rewrite the entire functionality of the module—otherwise it wouldn't be a mock! You can mock the pieces that you're using, but you do have to make sure that _those_ pieces are API compatible.
+
+However, instead of returning 100 posts from the `placeholderjson` API, our `fetch` mock just returns an empty array from its `json` method. You could put anything here——you could put the full 100 posts, have it "return" nothing, or anything in-between! By having control over _what_ the `fetch` mock returns we can reliably test edge cases and how our app responds to API data without being reliant on the network!
+
+Finally, the last portion of our mock is to restore the actual `global.fetch` to its former glory after all the tests have run. `afterAll` is a hook provided by `jest` that runs at the end of the test suite (just like `beforeAll` runs before the test suite), so we use it to set `global.fetch` back to the reference that we stored.
+
+This is important if you're running multiple test suites that rely on `global.fetch`. If you don't clean up the test suite correctly you could see failing tests for code _that is not broken_. What essentially happens is the subsequent test suites use the mock from _the earlier test suite_ and they're not expecting the same response (after all, that mock might be in an entirely different file 😱).
+
+Furthermore, your tests might not run in the exact same order each time so it's never a good idea to have tests share state. Instead, try to think of each test in isolation——can it run at any time, will it set up whatever it needs, and can it clean up after itself?
+
+### Method #2: Use `jest.spyOn` to do all the hard work for us
+
+Now that we've looked at one way to successfully mock out `fetch`, let's examine a second method using [Jest](https://jestjs.io/). If you haven't used [Jest](https://jestjs.io/) before, it's another testing framework built and maintained by the engineers at Facebook.
+
+One of my favorite aspects of using Jest is how simple it makes it for us to mock out code—even our `window.fetch` function! 🙌
+
+While the first example of mocking `fetch` would work in any JavaScript testing framework (like Mocha or Jasmine), this method of mocking `fetch` is specific to Jest. Here's what it would look like to change our code from earlier to use Jest to mock `fetch`.
+
+```diff
+-// Part 1
+-const unmockedFetch = global.fetch
+-
+-// Part 2
+-beforeAll(() => {
+-  global.fetch = () =>
+-    Promise.resolve({
+-      json: () => Promise.resolve([]),
+-    })
+-})
+-
+-// Part 3
+-afterAll(() => {
+-  global.fetch = unmockedFetch
+-})
+
++const fetchMock = jest
++  .spyOn(global, 'fetch')
++  .mockImplementation(() => Promise.resolve({ json: () => Promise.resolve([]) }))
+```
+
+Jest provides a `.spyOn` method that allows you to listen to all calls to any method on an object. To use `jest.spyOn` you pass the object containing the method you want to spy on, and then you pass the _name of the method as a string_ as the second argument.
+
+Jest's `spyOn` method returns a _mock function_, but as of right now we _haven't replaced the fetch function's functionality_. To do that we need to use the `.mockImplementation(callbackFn)` method and insert what we want to replace `fetch` with as the `callbackFn` argument. We can simply use the same `fetch` mock from before, where we replace `fetch` with `() => Promise.resolve({ json: () => Promise.resolve([]) })`.
+
+If you're not familiar with test spies and mock functions, the TL;DR is that a spy function _doesn't change any functionality_ while a _mock function replaces the functionality_. Test spies let you record all of the things that function was called. Later you can assert things based on what arguments the spy function received. For example, we could assert that `fetch` was called with `https://placeholderjson.org` as its argument:
+
+```js
+const fetchMock = jest
+	.spyOn(global, 'fetch')
+	.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+
+describe('withFetch', () => {
+	test('works', async () => {
+		const json = await withFetch();
+
+		// highlight-start
+		expect(fetchMock).toHaveBeenCalledWith('https://jsonplaceholder.typicode.com/posts');
+		// highlight-end
+
+		expect(Array.isArray(json)).toEqual(true);
+		expect(json.length).toEqual(0);
+	});
+});
+```
+
+The cool thing about this method of mocking fetch is that we get a couple extra things for free that we don't when we're replacing the `global.fetch` function manually. First off, instead of managing `beforeAll` and `afterAll` ourselves, we can simply use Jest to mock out the `fetch` function and Jest will handle _all of the setup and teardown for us_! Secondly, we make it a lot easier to spy on what `fetch` was called with and use that in our test assertions.
+
+## Customizing the mocked response for individual tests
+
+In addition to being able to mock out `fetch` for a single file, we also want to be able to customize _how `fetch` is mocked for an individual test_.
+
+The main reason that we want to be able to do this boils down to what the module we're testing is responsible for. If we have a module that calls an API, it's usually also responsible for dealing with a handful of API scenarios.
+
+For example, we know what this module does when the response is 0 items, but what about when there are 10 items? 100 items? What happens if the data is paginated or if the API sends back a 500 error?
+
+Our code that deals with external APIs has to handle a ton of scenarios if we want it to be considered "robust", but we also want to set up automated tests for these scenarios. Getting the API to return a 500 error might actually be a little difficult if you're manually testing from the front-end, so having a mocked `fetch` allows us to run our API handling code with every unit test run.
+
+In order to mock `fetch` for an individual test, we don't have to change much from the previous mocks we wrote! As a first step, we can simply move the mocking code _inside of the test_.
+
+```js
+describe('withFetch', () => {
+	test('works', async () => {
+		// highlight-start
+		const fetchMock = jest
+			.spyOn(global, 'fetch')
+			.mockImplementation(() => Promise.resolve({ json: () => Promise.resolve([]) }));
+		// highlight-end
+
+		const json = await withFetch();
+		expect(fetchMock).toHaveBeenCalledWith('https://jsonplaceholder.typicode.com/posts');
+
+		expect(Array.isArray(json)).toEqual(true);
+		expect(json.length).toEqual(0);
+	});
+});
+```
+
+And that's it! Now, if we were to add another test, all we would need to do is re-implement the mock _for that test_, except we have complete freedom to do a _different_ `mockImplementation` than we did in the first test.
+
+The big caveat of mocking `fetch` for each individual test is there is considerably more boilerplate than mocking it in a `beforeEach` hook or at the top of the module. However, if I need to switch how `fetch` responds for individual tests, a little extra boilerplate is much better than skipping the tests and accidentally shipping bugs to end users.
+
+---
+
+## Conclusion
+
+Mocking `window.fetch` is a valuable tool to have in your automated-testing toolbelt—it makes it incredibly easy to recreate difficult-to-reproduce scenarios and guarantees that your tests will run the same way no matter what (even when disconnected from the internet).
+
+If you enjoyed this tutorial, I'd love to connect! As always, you can [follow me on Twitter](https://twitter.com/benjamminj) or [connect with me on LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) to hear about new blog posts as I publish them.

--- a/packages/content/writing/moving-away-from-mdx.md
+++ b/packages/content/writing/moving-away-from-mdx.md
@@ -1,0 +1,38 @@
+---
+title: Moving away from MDX
+description: At least for blogging, plain markdown is less frictionG
+date: 2022-01-17
+tags:
+  - writing
+---
+
+I just [removed MDX files from my blog](https://github.com/benjamminj/portfolio/pull/162).
+
+I've left the MDX parser for now. But going forward, authoring in `.mdx` is gonna be the _exception_, not the _rule_. I might strip the MDX parser out entirely in favor a simpler parser, we'll see.
+
+This move has been something I've been contemplating for about a month now. Here's a few reasons why:
+
+## Why not MDX?
+
+In short, MDX is loaded with cool functionality, but it didn't actual problems in my authoring workflow. In fact, I felt like the added complexity created _more_ problems for me.
+
+- **Plain markdown is enough for me to express myself.** I didn't need all the bells and whistles of MDX. I don't have a lot of interactive demos or custom widgets when writing.
+- **Less constraints = more decisions.** I found the limitless possibilities of MDX to be paralyzing while writing. Instead of focusing on capturing my _thoughts_, I was stuck with questions like "should this be a `Callout` or a `blockquote`?" For my highly-distractable mind (see: [ADHD](https://www.additudemag.com/adhd-in-adults/)), this equals major friction while writing.
+- **Markdown is more portable.** I've been toying with the idea of separating my content from my website's code. Whether that's just a separate repository, something like Notion, or a real CMS, Markdown presents a much easier path forward. Most external tools (like Notion / [Bear](https://bear.app/)) even support a "export as markdown" feature!
+
+In short, I'm ditching MDX because I don't need the extra functionality it provides, and I lose a lot by having another complex tool in my build pipeline.
+
+## When should you reach for MDX?
+
+MDX isn't bad, just wasn't the right choice for my personal blog. Which begs the question, _**"When is MDX the right choice?"**_.
+
+MDX is great if you have highly interactive demos as part of your content. You can easily colocate the demos next to the content and weave static and dynamic fluidly.
+
+It's also great if your content is more flexible than plain Markdown allows. For example, you have a lot of different layouts or widgets.
+
+Finally, MDX is a fantastic choice for documenting component libraries. In this case, you're weaving static content (talking about components) with interactive (embedding the components themselves).
+
+## Extra reading
+
+- [Shortcodes vs MDX](https://www.swyx.io/shortcodes-vs-mdx-3d4e/) - This article largely sums up my sentiments about MDX — at the moment, I think simple markdown + shortcodes probably makes more sense.
+- [Josh Comeau's blog](https://www.joshwcomeau.com/blog/how-i-built-my-blog/) - This blog heavily uses MDX to build a fully-interactive reading experience. It's a great example of a use case where MDX makes total sense.

--- a/packages/content/writing/my-experience-at-thinkful.md
+++ b/packages/content/writing/my-experience-at-thinkful.md
@@ -1,0 +1,39 @@
+---
+title: My experience at Thinkful, ~5 years later
+description: What I learned in the bootcamp, and what I didn't.
+date: 2021-12-09
+tags:
+  - bootcamps
+  - career
+  - job-searching
+---
+
+I'm trying a new thing! When I get a question more than a couple times, it goes into the backlog of articles I need to write! Sadly, this backlog grows longer every week, maybe someday I'll run out of article ideas! 😱
+
+As a grad of Thinkful, I often get asked about my experience there -- did I like it and was it worth the tuition? If you're considering Thinkful (or a bootcamp in general), I hope this article helps you as you consider some really large decisions about learning programming.
+
+## tl;dr
+
+Thinkful was a great choice for me at the time I attended -- it fit _what I needed_. But make sure it fits what _you_ need if you're considering attending there, everything I write here was 5 years ago!
+
+## Why I attended Thinkful
+
+It's really important to choose a learning path that suits _your_ needs. For me, Thinkful fit the bill for a few reasons:
+
+- **Remote-first.** Thinkful is primarily a remote bootcamp, and I didn't want to be driving into in-person classes. Remote work was a big reason I was interested in getting into the software industry, even before COVID-19.
+- **Affordable.** Thinkful was more affordable than the other bootcamps that I looked at, and their billing structure allowed me to finance it with a loan and pay it slowly. I couldn't afford to do a CS degree as I had just graduated with a music degree a few years earlier (also time, 4 years is a long time).
+- **Part-time.** Thinkful had part-time (20h / week, 6 months) and a full-time (40h / week, 3 months) courses when I attended. Attending part-time allowed me to work as a valet and continue paying rent while I changed careers.
+- **Self-paced with mentorship.** The program I attended was mostly self-paced -- you met 1-on-1 with a mentor 3x per week. Mentors were usually senior engineers working for Thinkful as a side-gig, so they had real industry experience.
+- **Career services.** At the time, Thinkful offered a robust career services branch _after you graduated_. You met with a career mentor 1x per week, and if Thinkful couldn't place you in a full-time job/internship within 6 months they would refund your tuition. Lots of bootcamps offer this today, but back then it wasn't as common.
+
+## My experience
+
+Overall, I had a great experience at Thinkful! The self-paced curriculum paired with frequent lessons with my mentor worked well for me. Coming from a music background, learning to code felt like learning an instrument -- you had lessons with a teacher and homework to do between lessons.
+
+Another thing that allowed me to learn deeply was taking the course at a part-time pace. I was only expected to do ~20 hours of work per week, but I probably ended up coding for ~30 hours per week. This gave me some extra time to get lost in rabbit holes and _be curious_ about the things I was learning (in retrospect, I blame my then-undiagnosed ADHD).
+
+Finally, career services was critical to my job search. I graduated early (I joke that I dropped out) to take an internship that I had gotten through my network. That internship didn't pan out into the full-time opportunity I thought it would be, so I _went back to career services_. With a lot of valuable [lessons I learned in career services](/getting-your-first-software-engineering-job), I had a full-time offer 3-4 months later.
+
+---
+
+I hope this was helpful to you! If you're considering getting into software engineering and you have more questions, feel free to reach out to me on [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (please include a note, I might not accept otherwise).

--- a/packages/content/writing/react-key-prop.md
+++ b/packages/content/writing/react-key-prop.md
@@ -1,0 +1,220 @@
+---
+title: 'Cheat sheet: using keys in React'
+description: 'A couple recommendations (and warnings) about using the "key" prop'
+date: 2020-08-24
+tags:
+  - react
+  - javascript
+---
+
+I recently did a little refresher on how React keys work under the hood. Here's my cheat sheet on using React keys "dos and don'ts".
+
+## Use keys when rendering lists
+
+React makes sure you know about this rule with keys—if you render a list of items without keys React throws a console error in development.
+
+For example, consider the following JSX.
+
+```jsx
+const items = ['A', 'B', 'C'];
+
+const MyList = () => {
+	return (
+		<ul>
+			{items.map((letter) => (
+				<li>{letter}</li>
+			))}
+		</ul>
+	);
+};
+```
+
+If you render this component in a React app you'll see the following error.
+
+```
+Warning: Each child in a list should have a unique "key" prop.
+```
+
+This error be removed by attaching a `key` prop to each `li` inside of the `map`:
+
+```jsx
+const items = ['A', 'B', 'C'];
+
+const MyList = () => {
+	return (
+		<ul>
+			{items.map((letter) => (
+				<li key={letter}>{letter}</li>
+			))}
+		</ul>
+	);
+};
+```
+
+React uses these keys to optimize rendering of the list items. When items are added, deleted, or swapped inside of the list, React uses that `key` to determine which items changed.
+
+If the `key` is the same value, but in a different array _position_, then React can just reorder the rendered list items instead of recalculating them. But if the `key` is a different value, React knows it has to rerender the list item.
+
+## Put the key _in the array itself_.
+
+The `key` prop should be applied directly within the array. It doesn't matter whether it's a React component or a JSX element (HTML elements, like `li` or `div`).
+
+The rule of thumb recommended in the React docs is to _use `key` whenever you're inside the `map` method_.
+
+## Use a unique value as a key.
+
+We need to use a _unique_ value for each key. This is important—duplicate keys in our array React will throw another console error!
+
+```jsx
+const items = [
+  { id: '123', value: 'A' },
+  { id: '456', value: 'B' }
+  { id: '789', value: 'A' }
+]
+
+const MyList = () => {
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.value}>{item.value}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+In the above example, we'll have two items that use `"A"` as their key, since we're using `item.value`. We'll get the following console error:
+
+```
+Warning: Encountered two children with the same key, `A`. Keys should be unique
+so that components maintain their identity across updates. Non-unique keys may
+cause children to be duplicated and/or omitted — the behavior is unsupported
+and could change in a future version.
+```
+
+Duplicate keys can be a source of some really strange bugs. For example, changing a components' state affects _a different component_ or items that don't properly update when you expect them to. 😱
+
+We can fix this error if we use `id` on each item, which **is** unique. Most times that we're rendering data we'll have something like an `id` that we can use for a `key`.
+
+```jsx
+const items = [
+  { id: '123', value: 'A' },
+  { id: '456', value: 'B' }
+  { id: '789', value: 'A' }
+]
+
+const MyList = () => {
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>{item.value}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Use the array index as a last resort
+
+One might be tempted to use the array index of the list item as the `key` prop. After all, that's unique, right?
+
+In fact, [the React docs explicitly say](https://reactjs.org/docs/lists-and-keys.html#keys) that using the array index as a `key` is not recommended. Under the hood, React already uses the `index` as the key if there isn't an explicit `key` prop.
+
+When you use an `index` as the key, React treats it the same as using _no key_. It only removes the console error.
+
+When using the `index` in the `key`, React isn't able to optimize rendering of added, deleted, and reordered items.
+
+_Note: using an `index` as the `key` is ok **if there is no other unique value** that can be used as a `key`. If you won't be adding, removing, or reordering your arrays, you can likely use `index` and be fine._
+
+If we add an item to the front of our list, every existing item has its' index incremented by `1`. If we're using `index` for the `key`, every key changes and React has to rerender the entire list.
+
+Lastly, using the `index` inside of string `key` doesn't change this behavior—the `key` still changes when we reorder the list. It doesn't matter whether they're on their own or part of a larger string.
+
+```jsx
+const list = ['A', 'B', 'C'];
+
+const ListWithIndexInString = () => {
+	return (
+		<ul>
+			{list.map((letter, i) => (
+				// This is exactly the same as `key={i}`
+				<li key={`letter-${i}`}>{letter}</li>
+			))}
+		</ul>
+	);
+};
+```
+
+## Keys only need to be unique across siblings
+
+Even though component keys need to be unique within an array, they only need to be unique [**from their sibling components**](https://reactjs.org/docs/lists-and-keys.html#keys-must-only-be-unique-among-siblings). This is important to remember because it simplifies the `key` values that we choose.
+
+This aspect of keys is also one of the most misunderstood (or ignored) that I've seen in the wild.
+
+The following is correct `key` usage, despite the same keys appearing in multiple places:
+
+```jsx
+const items = ['A', 'B'];
+
+const MyList = () => {
+	return (
+		<ul>
+			{items.map((outerLetter) => (
+				<div key={outerLetter}>
+					{items.map((innerLetter) => (
+						<li key={innerLetter}>
+							{outerLetter}: {innerLetter}
+						</li>
+					))}
+				</div>
+			))}
+		</ul>
+	);
+};
+```
+
+There's no need for use to make keys like `` `outerItem__${outerLetter}` `` and `` `innerItem_${innerLetter}` `` that are unique across the entire component. We just need to make sure that _sibling_ components have unique keys.
+
+Sometimes tracing the `key` values can be a little tricky, especially with the nested `map`s. I find it helpful to think about the tree that React builds while rendering these components:
+
+```js
+const tree = {
+	root: {
+		type: 'ul',
+		children: [
+			{
+				type: 'div',
+				key: 'A',
+				children: [
+					{ type: 'li', key: 'A', children: ['A: A'] },
+					{ type: 'li', key: 'B', children: ['A: B'] }
+				]
+			},
+			{
+				type: 'div',
+				key: 'B',
+				children: [
+					{ type: 'li', key: 'A', children: ['B: A'] },
+					{ type: 'li', key: 'B', children: ['B: B'] }
+				]
+			}
+		]
+	}
+};
+```
+
+Using the following tree, we can see that key uniqueness only matters at **each indentation level**. Two components are at different levels of the tree can have the same `key` values without there being any problem.
+
+---
+
+## tl;dr
+
+Use a `key` prop to allow React to optimize adding, deleting and reordering list items. `key` values should be unique, but they only need to be unique across sibling components.
+
+---
+
+## Resources
+
+- [Lists and keys (React docs)](https://reactjs.org/docs/lists-and-keys.html): the official docs on keys are fantastic—they thoroughly explain how to properly (and improperly) use keys.
+- [Reconciliation (React docs)](https://reactjs.org/docs/reconciliation.html#recursing-on-children): this is a deep-dive into how React turns JSX into actual rendered HTML, as well as why keys are necessary.
+- [Index as a key is an anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318): this article describes a couple potential bugs that can come from using `index` as the key prop.

--- a/packages/content/writing/refactoring-legacy-code-with-jest-snapshots.md
+++ b/packages/content/writing/refactoring-legacy-code-with-jest-snapshots.md
@@ -1,0 +1,14 @@
+---
+title: 'Refactoring legacy code with Jest snapshots'
+description: In this article I share a method for introducing a little safety when working with legacy code without having to pause and set up a full testing suite.
+draft: false
+date: 2019-03-26
+publisher: LogRocket
+link: https://blog.logrocket.com/refactoring-legacy-code-with-jest-snapshots-e290ceccccc3/
+tags:
+  - testing
+  - jest
+  - javascript
+---
+
+In this article I look at some of the downsides to snapshot testing and why it generally isn't the best approach for your long-term testing strategy. I then share an appropriate use-case for snapshot testing to help when refactoring legacy code.

--- a/packages/content/writing/regex-test-side-effects.md
+++ b/packages/content/writing/regex-test-side-effects.md
@@ -1,0 +1,110 @@
+---
+title: Using "regex.test" with the "global" flag
+date: 2020-07-23
+draft: false
+tags:
+  - javascript
+  - regex
+---
+
+I recently came up on this JavaScript quirk while debugging some form input validators that were failing intermittently. When I finally found the source of the bug, I was surprised at this behavior from the seemingly innocent [Regex.prototype.test](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) function.
+
+If you're not familiar with `Regex.prototype.test` it seems somewhat straightforward: take a regular expression (regex) in JavaScript and plug a string into its `test` method. If the string matches the regex, the method returns `true`. Otherwise it returns `false`.
+
+There's one caveat.
+
+_If the regex being tested contains the global flag, `regex.test(str)` relies on more than just the input `str`._
+
+## So what's going on?
+
+To put it in functional programming terms—`regex.test` is not a pure function if you use the `g` flag on your regex.
+
+Here's an example of this behavior in action.
+
+```js
+// note that we're using the `g` flag
+const regex = /test/g;
+
+// returns true
+regex.test('test123');
+
+// returns false 😭
+regex.test('test123');
+
+// returns true
+regex.test('test123');
+```
+
+Why does this happen? Is it that the JavaScript gods are fickle and have chosen to punish us mortal programmers for not choosing a language like Java? Is it baked into the language so that we can have one more piece of trivia to stump candidates in interviews? (Don't do this btw. Interviews are about seeing whether someone is a good fit for your company, not about proving you're smarter than them).
+
+The reason that this happens is because JavaScript regexes contain a [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) property that tells `regex.test` and [regex.exec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) where to start searching the input string.
+
+Both methods set the `lastIndex` value on the regex to the _last matched index_. But they only do this if the regex has the `g` flag. If the end of the string is reached without finding any matches, `lastIndex` is set to `0`.
+
+Here's the same example from before, but also showing the value of `lastIndex`:
+
+```js
+// note that we're using the `g` flag on the
+const regex = /test/g;
+console.log(regex.lastIndex); // 0
+
+// returns true
+regex.test('test123');
+console.log(regex.lastIndex); // 4
+
+// returns false 😭
+regex.test('test123');
+console.log(regex.lastIndex); // 0
+
+// returns true
+regex.test('test123');
+console.log(regex.lastIndex); // 4
+```
+
+## How do we work around this quirk?
+
+There's a couple ways that we can write our application to be resilient against bugs stemming from this JavaScript gotcha.
+
+Certainly the simplest way to get around this issue is to remember that `regex.test` behaves like this if the `g` flag exists and not use it on regexes that have the `g` flag.
+
+Especially if the primary usage of the regex is testing strings, we probably don't need the `g` flag since we can either just test for the existence of a match (no `g` flag) or that the string starts/ends how we expect (using `^`, `$`, [groups, and ranges](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)).
+
+We could have avoided the entire problem if we just removed the `g` flag from the regex itself.
+
+```js
+const regex = /test/;
+
+// returns true
+regex.test('test123');
+
+// returns true 🎉
+regex.test('test123');
+```
+
+Personally, I think this is the ideal solution—we're using the method as intended, and our regexes reflect the way that we intend them to be used.
+
+Sometimes this isn't perfectly possible though. Perhaps you're using the regex in another context where it needs to have the `g` flag. Perhaps you're not entirely sure _which_ regex will be passed in to your code and you just want to make it more predictable.
+
+If the regex absolutely _has_ to have the `g` flag, we can provide some much-needed purity to our code by using the slightly less ergonomic [String.prototype.match](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) method and casting it into a `Boolean`.
+
+```js
+// note that we're using the `g` flag again
+const regex = /test/g;
+const str = 'test123';
+
+// returns true
+Boolean(str.match(regex));
+
+// returns true 🎉
+Boolean(str.match(regex));
+```
+
+It's not as ergonomic, but it still provides the same `boolean` result. Since `string.match` returns an array of matches and `null` if there's no matches in the string, we can turn this into a `boolean` just by wrapping it in the `Boolean` function to convert it.
+
+## tl;dr
+
+_JavaScript's `regex.test(str)` mutates a `lastIndex` property. The next time you call `regex.test` it starts testing `str` from `lastIndex` instead of the beginning. This means that multiple calls to `regex.test` might return different results, even if they were called with the same arguments._
+
+---
+
+Feel free to hit me up on my [Twitter](https://twitter.com/benjamminj) or [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) with any thoughts or if you enjoyed this article. If you found a typo or have some feedback for improvement also feel free to [submit a pull request](https://github.com/benjamminj/portfolio). Thanks for reading! 🎉

--- a/packages/content/writing/small-prs.md
+++ b/packages/content/writing/small-prs.md
@@ -1,0 +1,55 @@
+---
+title: How to create small PRs
+subtitle: Make your team's life easier by keeping diffs small.
+date: 2021-09-15
+tags:
+  - teamwork
+  - pull-requests
+  - software-engineering
+---
+
+When you work in teams, you'll spend lots of time reviewing code. And at some point you'll get assigned a PR that's 1,000+ lines long.
+
+Guess what? That PR is gonna take a long time to review unless you just slap a "LGTM" comment and YOLO-approve it.
+
+In contrast, small PRs result in higher-quality reviews and faster turnaround time.
+
+But how do you go from sending your teammates behemoth PRs to creating small, independently mergable diffs? Here's a few techniques to take those mega PRs and make them easier to review.
+
+## Split large features into multiple PRs
+
+The common reason behind large PRs is putting _**everything**_ for a new feature in a single PR. Sometimes it's 2-3 days' work, other times it could be _**weeks**_ of work. 😱
+
+Instead of working on the entire feature and _then_ opening a massive PR, try splitting the feature into multiple chunks that can each be merged separately.
+
+For example, do the backend in one PR and the frontend in another, or add the UI with mock data and do a second PR to wire up the API. Or do refactoring in a PR before you add the new behavior.
+
+You might even be able work in parallel with someone else on your team depending on how you split the tasks!
+
+Is splitting a complex feature up into multiple PRs a lot of extra work? 100%. But it makes life _way_ easier on your reviewers, which is well worth it.
+
+## Feature. Flags.
+
+If you're doing continuous deployment, splitting a big feature into small PRs poses a new problem—how do you safely merge work that's half-baked?
+
+Enter [feature flagging](https://martinfowler.com/articles/feature-toggles.html).
+
+Feature flagging allows you to keep merging code and deploying it to production without actually showing it to users. Then, once you're confident the feature is ready you can flip the flag on and send it to real users!
+
+This pairs nicely with small PRs since you don't need to wait for a feature to be "done" before you merge it in.
+
+## Watch the size of your diff, and look for stopping places
+
+When I'm working on a big feature, I'll do my work normally, but I'll also periodically check to see the size of my diff. If that diff starts getting large (for me that's ~400 lines) I'll start looking for a good way to open a PR for my in-progress work.
+
+It's better to start looking for a stopping place early than it is to push up your work only to realize your PR is 1,200 lines long.
+
+---
+
+## Conclusion
+
+Learn how to create small PRs and you'll notice they get reviewed a lot faster. While it's not an easy skill to develop, it's certainly a valuable one, especially when you're working in a team. After all, the main point of PRs is _**communication**_, not gatekeeping!
+
+## Extra resources
+
+- [Small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html) by Google engineering. _(CL is short for **change list**, which to my understanding is the same as a pull request)_.

--- a/packages/content/writing/testing-animations-in-react-native.md
+++ b/packages/content/writing/testing-animations-in-react-native.md
@@ -1,0 +1,164 @@
+---
+title: Testing Animated Components in React Native
+description: As a result of my issues with testing React Native components with animations I learned quite a bit about how React Native and Jest environment are set up.
+date: 2019-02-17
+tags:
+  - react-native
+  - testing
+---
+
+I came up upon this issue a couple weeks back and it's been bouncing around my head as food for a blog post since. I've always thought that the "write the blog post you wish you had" concept is great. The hard part is that after you're done solving difficult problems, you barely have any energy left to write the post!
+
+Anyways, I've been working a fair amount in React Native the past few months. It's certainly been a learning experience since this is my first time delving into native development. In addition, something that I'm pretty passionate about is setting up a solid testing suite for whatever project I'm working on (that is, if it doesn't already have tests). I'm a firm believer that a well-written testing suite can [save hours of time and thousands of dollars](https://www.computer.org/csdl/mags/so/2007/03/s3024.pdf).
+
+As a result I've been learning quite a bit about testing React Native apps with Jest. And recently I came up on an especially tricky test. I had this component that contained an animation—via React Native's `Animated` module. Internally, the component triggered some state changes along with some animations. While I can't share the actual component in this post, I do want to document how to manage these types of tricky tests.
+
+In my unit test I wasn't trying to do anything _too_ fancy. Render the component, fire some "onPress" events, and then run some assertions on how the component had changes. But the first time I ran my tests, I ended up with the following error:
+
+```
+ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
+```
+
+When the test runs the state update, this triggers the animation inside the component. However, by the time that the animation runs, the test has already run all of its assertions and completed. So by the time the [animation's callback](https://facebook.github.io/react-native/docs/animated#working-with-animations) triggers a `setState`, the component has already unmounted!
+
+## Why can't we just mock `Animated`?
+
+As a first solution, I thought I might be able to get away with mocking out the entire `Animated` module from React Native. However, after some consideration I decided _against_ this for a few reasons.
+
+First off, the `Animated` module is decently complex, and coming up with a solid mock is not a small feat. It contains multiple animation components, functions to control timing and easing, and some of the APIs allow [method chaining](https://javascriptissexy.com/beautiful-javascript-easily-create-chainable-cascading-methods-for-expressiveness/). When mocking it's important to have something that's API-compatible with the real module—or at least the parts that you're using. I found that my component was using a sizable portion of the `Animated` API, so it would take quite a bit of effort to mock it out. While not impossible, it's worth acknowledging that a mock wouldn't be simple.
+
+However, that's not the only reason. Whenever you mock out a module you decrease the similarity that your code _under test_ has to your code _in the real world_. There's a lot of opinions about this, for example this article on [why mocking is a code smell](https://medium.com/javascript-scene/mocking-is-a-code-smell-944a70c90a6a). My preference is to lean more on the side of integration testing and less on mocking when it comes to testing software (especially for front-end apps). So, I wanted to actually use the `Animated` module to make sure that my tests were more accurate.
+
+What I wanted is to mock _something_ in the testing environment that allowed me to use the _real_ `Animated` module _without throwing the Jest error_.
+
+## Why we can't only use `jest.useFakeTimers`
+
+Jest ships with a tool exactly for testing these scenarios—[`jest.useFakeTimers`](https://jestjs.io/docs/en/timer-mocks.html). Using `jest.useFakeTimers` allows us to mock out _time itself_ and how the test runner progresses through time.
+
+So I figured I'd try it out. All you've got to do is call the function at the top of your test suite:
+
+```jsx
+beforeEach(() => {
+	jest.useFakeTimers();
+});
+```
+
+And then to advance the fake time, you can do something like this:
+
+```jsx
+// inside a test
+// move forward 500ms
+jest.advanceTimersByTime(500);
+```
+
+Turns out this creates an _entirely new error_ specific to only the testing environment. The error goes something like this:
+
+```
+Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out...
+```
+
+### Why do we get `Ran 100000 timers, and there are still more!`?
+
+This error was even more cryptic to me and the first one! And when it came to finding out the answers, I had to spend a long time digging through StackOverflow posts and GitHub issues. Fortunately, I eventually stumbled on [this StackOverflow answer](https://stackoverflow.com/a/51067606).
+
+Turns out, React creates a polyfilled version of `requestAnimationFrame` in order to run its animations. And that Reach Native's implementation of `global.requestAnimationFrame` uses `setTimeout(fn, 0)` under the hood. While this is all good in normal execution context (it just runs on the next tick of the runtime), when we're using `useFakeTimers` the `setTimeout(fn, 0)` spins off a bunch of new timers (1 per timeout) very quickly. This causes Jest to bail out because the stack gets too large and it thinks that you accidentally created an infinite recursion. Not good!
+
+## Time travelling (and StackOverflow) to save the day
+
+In addition to finding out why I was getting this cryptic error, I also found a really nice solution on StackOverflow that I adapted to actually be able to test animations reliably—without extensive mocking of `Animated`.
+
+This is only slightly adapted—personally, I don't like 100% copy-pasting code from StackOverflow. I find that when I take the time to rewrite the code in my own "words" I understand what's actually happening a bit better—even if it looks almost identical to the original code.
+
+So let's see how we could implement a solution.
+
+First, we need to mock out the `requestAnimationFrame` to not use `setTimeout(fn, 0)` under the hood. If we assume that we'll be using `jest.useFakeTimers` to actually move _forward_ through time, `setTimeout` itself isn't the issue. The issue is `useFakeTimers` along with `setTimeout(fn, 0)`. So what we can do is change the timeout that `requestAnimationFrame` uses under the hood.
+
+```jsx
+// in a test setup file, or your test itself
+const FRAME_TIME = 10;
+
+global.requestAnimationFrame = (cb) => {
+	setTimeout(cb, FRAME_TIME);
+};
+```
+
+What this does is simulate a new frame every 10 milliseconds. You could put any number here, but the reason why I like 10 for the timeout amount is because it allows us to avoid mathematical gymnastics inside of our unit tests. For example, if we travel forward by 300ms, it's easy to mentally calculate that we'll advance by 30 frames.
+
+Now that we've polyfilled `requestAnimationFrame`, the next order of business is to set up a `timeTravel` function. This makes sure that when we're travelling forward through time we do all of the things necessary so that React Native's animations run correctly in the test environment.
+
+```jsx
+// timeTravel.js
+import MockDate from 'mockdate';
+
+const FRAME_TIME = 10;
+
+const advanceOneFrame = () => {
+	const now = Date.now();
+	MockDate.set(new Date(now + FRAME_TIME));
+	jest.advanceTimersByTime(FRAME_TIME);
+};
+
+const timeTravel = (msToAdvance = FRAME_TIME) => {
+	const numberOfFramesToRun = msToAdvance / FRAME_TIME;
+	let framesElapsed = 0;
+
+	// Step through each of the frames until we've ran them all
+	while (framesElapsed < numberOfFramesToRun) {
+		advanceOneFrame();
+		framesElapsed++;
+	}
+};
+
+export default timeTravel;
+```
+
+It's worth noting that we _do_ need this `timeTravel` function in addition to the `requestAnimationFrame` polyfill. The main reason has to do with the way that React Native's `Animated` module calculates elapsed time (and an animation's progress). Under the hood, it uses the current date (`Date.now`) to calculate how much time elapsed since the animation began.
+
+As a result, we have to make sure that each frame we advance in `timeTravel` updates `Date.now`. In the `advanceOneFrame` function we take the current `Date.now` value and make sure that it advances forward by one "frame" (10ms). I'm using a library called [`MockDate`](https://github.com/boblauer/MockDate) which makes testing with dates an absolute breeze. In addition, we advance the Jest timers using `jest.advanceTimersByTime`. This makes sure that our Animation is calculated correctly _and_ our `setTimeout`s get called without creating infinite recursion.
+
+Then, in the `timeTravel` function we take a single argument—the amount of time to "move forward"—and use it to calculate how many frames this would be. After that it's a matter of wrapping our `advanceOneFrame` function inside a `while` loop. This makes sure we keep stepping forward one frame at a time until we've hit our `msToAdvance` number.
+
+Lastly, we need to do a little bit of setup in order to use this function. I find it helpful to create a `setupTimeTravel` function that can be dropped into Jest's `beforeEach` whenever I make test utilities like this. Even though our `setupTimeTravel` function isn't too complex, it's useful since it keeps everything related to this utility contained to one place.
+
+```jsx
+// timeTravel.js
+export const setupTimeTravel = () => {
+	MockDate.set(0);
+	jest.useFakeTimers();
+};
+```
+
+The first line of our `setupTimeTravel` function isn't 100% necessary, but it certainly helps. Because `Animated` relies on `Date.now` to calculate elapsed time, setting it to `0` makes it easier to reason about our animation logic later on. However, you _could_ get by without it, so leave it out if you want to!
+
+However, we do need to use `jest.useFakeTimers` in our `setupTimeTravel` function—if you leave this out the `timeTravel` function won't work!
+
+### Using our `timeTravel` function in a test
+
+Now that we've got our brand new `timeTravel` function, let's see what it could look like in a test!
+
+```jsx
+import { timeTravel, setupTimeTravel } from './path-to/timeTravel';
+
+beforeEach(setupTimeTravel);
+
+describe('<ComponentWithAnimation />', () => {
+	test('works with animations', () => {
+		// render the component
+		// trigger some animation
+
+		// this actually moves the timers forward
+		// and simulates the frames over 500ms
+		timeTravel(500);
+
+		// run assertions on the animated state here
+	});
+});
+```
+
+---
+
+## Conclusion
+
+I thought that this issue with testing React Native Animations was especially interesting. As a result of my issues with testing this component I learned quite a bit about how React Native calculates animation duration as well as how the Jest environment was set up. When I was googling all over for that "Ran 100000 timers, and there are still more!" error, there wasn't too much to find, and if I had this blog post then it certainly would have been helpful! I hope that this was helpful to any of you reading along!
+
+If you enjoyed reading this article, you're welcome to check out and follow me on [Twitter](https://twitter.com/benjamminj). I promise I'll share any time I post something new. And if you want to edit this post at all please feel free to open a [PR on GitHub](https://github.com/benjamminj/portfolio). Thanks for reading! 🎉

--- a/packages/content/writing/things-to-keep-an-eye-on-in-2018.md
+++ b/packages/content/writing/things-to-keep-an-eye-on-in-2018.md
@@ -1,0 +1,44 @@
+---
+title: 5 Front-End Technologies I'm Keeping My Eye on in 2018
+description: Here's some things I'm placing bets on & diving into in 2018.
+date: 2018-01-06
+image:
+  url: 'ace-card.jpg'
+  alt: Ace of Spades against a black background
+---
+
+My wife is from Las Vegas. At New Years Eve just a week ago, Las Vegas swarmed with over 300,000 guests. Some of those guests left a lot richer than when they were when they arrived in Vegas, no doubt having won a sheer stroke of luck (or maybe skill, they claim). Others, not so much.
+
+Learning new technologies can sometimes feel akin to gambling &mdash; especially if you feel that your time has value to it. You can sink hours of ever-so-precious personal time into learning some new framework, language, or programming paradigm only to watch it fall into obscurity 3 months later. On the flipside, there's tremendous gains to be won if you choose wisely and become an early adopter of "the next big thing".
+
+2017 was a big year for me &mdash; at the beginning of the year I was just starting to dive into React & the modern JavaScript ecosystem. Up until then, I'd mostly been working with more legacy codebases & jQuery as the frontend library of choice. And now, less than 1 year later, I've been working as a professional React developer for roughly 6 months at a top-notch [startup](https://www.autogravity.com) based in Irvine.
+
+Throughout the last year I did some gambling on which technologies I'd learn on my free time &mdash; I won a few, and had quite a few that didn't pay off as well as I'd hoped.
+
+Anyways, here's some things I'm placing bets on & watching/diving into in 2018.
+
+## React
+
+This is a safe bet...it's also hard to ignore that React is currently the 200-ton juggernaut in the front-end space, and it doesn't look like anything is going to usurp its position soon. I'm using React every day at work, and it's not too much extra effort to stay up to date on modern component architectures, API changes, best practices, etc. happening in the React space. In addition, the team behind React is doing an amazing job at staying at the cutting edge of modern web development.
+
+## WebAssembly
+
+In mid-November of 2017 [Mozilla announced](https://blog.mozilla.org/blog/2017/11/13/webassembly-in-browsers/) that support for WebAssembly ships by default in all major modern browsers (sorry, IE11 users, but you're not a "major browser" anymore). With growing support of this new web standard I think web development will start to see new paradigms and best practices pop up as many traditionally server-side & embedded systems programming languages suddenly become available on the web.
+
+## Web Components & Custom Elements
+
+Web Components/Custom Elements allow for a ton of awesome things in front-end development. An obvious plus from using them is simple framework-agnostic sharing of styles & UI components. This means that developers using these components (whether it's you using your own, open source users, or other developers within your organization) don't have to bother about which framework/library/rendering engine you used to write components, they can simply use them the same way they use a `<button>` or an `input` tag. Furthermore, it will be interesting to see what front-end architectures arise as companies use custom elements more and more &mdash; some people are already advocating for a "[microservices for the front-end](https://micro-frontends.org/)" approach towards building UIs.
+
+## CSS Variables
+
+CSS Custom Properties (CSS Variables) are currently supported in the four major modern browsers. They essentially allow you to store values in a variable that is evaluated by the CSS parser _at runtime_. This is far more flexible & leads to more interesting usages than preprocessor variables that get evaluated in a compile step (especially when paired with a framework like React). I think that much like we saw **tons** of best practices & tutorials emerging for CSS Grid in the latter half of 2017, we're gonna see tons of developers discovering & sharing best practices around CSS Custom properties in 2018.
+
+## GraphQL
+
+GraphQL got reeeallly big in 2017. Right now, the list of companies using this technology is a who's who of the tech scene: Facebook, GitHub, Pinterest, Intuit, etc. Basically, GraphQL operates as a "query language for your API", allowing the user of the API to retrieve only the data they've explicitly requested. However, I'm seeing a trend of beginning to use GraphQL for querying things other than API endpoints &mdash; [Gatsby's](https://www.gatsbyjs.org/docs/) currently using it to query all data & generate static sites, and I recently saw [another project](https://dev-blog.apollodata.com/the-future-of-state-management-dd410864cae2) working to use GraphQL as a frontend state management tool. It's no doubt that as it becomes more familiar and we see more success stories from larger companies that it will only increase in adoption.
+
+## Conclusion
+
+Let's set one thing straight here, though. **It's 100% possible that I'm wrong about any of these predictions.** After all, choosing technologies is gambling, and when you gamble sometimes you lose. However, these are all technologies that I've seen gaining traction in 2017 and I think they all show promise. It's also important to remember that this list isn't inclusive of _everything that's interesting to me_, but rather kinda a "top picks" specifically for the front-end web development space at this given point in time.
+
+What about you? What things are you interested in for 2018? Feel free to [tweet at me](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) if you've got thoughts to share. 😎

--- a/packages/content/writing/thoughts-on-elm.md
+++ b/packages/content/writing/thoughts-on-elm.md
@@ -1,0 +1,164 @@
+---
+title: Some Thoughts on Elm
+date: 2018-01-27
+description: Elm is a functional compile-to-JavaScript language used for building robust, bug-resistant UIs.
+image:
+  url: 'elm-logo.png'
+  alt: Elm Logo
+tags:
+  - functional-programming
+---
+
+I've been playing around with Elm off & on since mid-2017. In short, Elm and I have a complex relationship. I **love** Elm as a language &mdash; the syntax just kinda gets out of your way / lets you focus on what you're actually writing, and the compiler is a strict-yet-loving teacher. In addition, it's a huge relief to feel confident that _code that compiles will not throw runtime exceptions_.
+
+However, at the same time the rest of the front-end ecosystem is sprinting onward (on many fronts!) & I'm using React at work, so it's difficult to devote any significant portion of my free time to playing around with Elm.
+
+For those of you that aren't too familiar with Elm, it's a functional _compile-to-JavaScript_ language primarily used for building robust, bug-resistant UIs. Even though it's a completely different language than JavaScript, it's intended use case sets it in direct competition with other JavaScript frameworks, like React, Angular, & Vue. However, the differences are **huge** (for better or for worse) &mdash; Elm really is a completely different language!
+
+Here's a couple of the key differences that I've experienced in the past few months of playing with Elm.
+
+## Pros
+
+### 1. Strong Typing
+
+Elm is a _strongly-typed_ language, as opposed to JavaScript's _weak typing_. This means that all of the functions you declare have a _type signature_.
+
+For example, if I wrote a function named `add` that takes two numbers & returns the added result, it would look like this.
+
+<u>**JavaScript:**</u>
+
+```javascript
+const add = (a, b) => a + b;
+```
+
+<u>**Elm:**</u>
+
+```haskell
+add: Number -> Number -> Number
+add a b =
+  a + b
+```
+
+The key to strong typing comes in when I want to _ actually use_ the function. What happens if I forget to pass a number & instead pass strings as my parameters?
+
+<u>**JavaScript:**</u>
+
+```javascript
+const sum = add('a', 'b'); // returns the string "ab" 🤔
+```
+
+<u>**Elm:**</u>
+
+```haskell
+sum = add "a" "b" -- throws a compiler error that's helpful! 🎉
+```
+
+The definition of the function in Elm includes a _type signature_ &mdash; indicating that the `add` function takes 2 numbers as parameters & returns a number as a result. Since the Elm compiler is usually smart enough to _infer_ your type signatures for you, you don't actually have to type this signature to get all the strongly-typed goodies. However, I found that as I played more with Elm, I found myself thinking about the type signatures of the functions that I was writing.
+
+While JavaScript has had a few attempts to bring types to it (notably [Flow](https://flow.org/) & [TypeScript](https://www.typescriptlang.org/)), they both fall way short of Elm's type syntax & static type checking capabilities. In Elm, type declarations feel more like a first class citizen, encouraging developers to think about types more often.
+
+### 2. Enforced Error Handling
+
+In Elm, the compiler will get reaaaaaaallly angry if you don't handle potential points of failure in your application code.
+
+For example, let's say you make a network request for some JSON. You're gonna operate on this JSON blob to render a blog post (like the one you're reading. Thanks 😜) You expect the JSON to look like this.
+
+```json
+{
+	"title": "Some cool stuff about Elm",
+	"body": "It's fun!",
+	"author": "Benjamin Johnson",
+	"dateCreated": "2018-01-25"
+}
+```
+
+Easy peasy, right? You just get the JSON, and use the appropriate keys to render your blog post.
+
+**Not so fast.**
+
+What happens if the network went down in between when the user loaded your web page & when they made this request?
+What happens if the JSON sends back an array of authors instead of a String?
+What happens if `dateCreated` is `null`?
+
+All of these are possiblities, especially if you're relying on a third-party API to deliver your content or you're working with other developers. And as much as you might want to say "That shouldn't happen. The backend engineers will let me know when they change the payload", the fact is that sometimes this type of stuff happens, even in the best of organizations.
+
+In JavaScript, you _could_ (not saying you always do, & definitely not saying you should!) write the code to assume that the JSON response loads perfectly every time. You might not find out that your app failed until you get either an error saying `` Cannot read property `body` of `undefined`. `` and now you have to crawl through a debugger. Or you accidentally render the word `null` to your screen. Not the best UX by a long shot.
+
+Elm forces you to write error-handling code for any operations that could _potentially fail_. Like network requests, or GeoLocation in the browser, or time-based operations (converting a string into a timestamp, for example). The main reason it's even capable of doing this is the static type system. When the compiler sees one of these "potentially failable" operations without error-handling code, it just refuses to compile until you write something to handle your errors.
+
+Like I said, it's possible to write JavaScript that handles those potential errors, but it's really helpful to have the compiler on your side when you forget to write an error handler. I've seen a lot of bugs that happened because a developer forgot to handle an edge case or write code that was defensive to all points of failure.
+
+### 3. Purely Functional
+
+While a purely functional language is awesome, purity without some form of state management doesn't work well for UIs (we need to be able to respond to user input & state changes 😜). Elm keeps the language pure by managing state mutations inside of the Elm runtime. This method of managing state updates, more commonly known as "[The Elm Architecture](https://guide.elm-lang.org/architecture/)" is also quite common outside of the Elm community (React + Redux is a prime example).
+
+Programming with this paradigm makes your UI a pure function of application state, meaning that it becomes incredibly simple to reason about portions of your app. _Everything in Elm is just a function_, and this tends to produce fairly readable, easy-to-reason-about code (a win in every way!).
+
+## Cons
+
+### 1. It's Hard To Beat The JavaScript Ecosystem
+
+Say what you want about the "JavaScript fatigue" & having a new framework pop up each week: there's a _ton_ of competition in the front-end JS world, and this results in the best solutions rising to the top (usually).
+
+Also, if you're playing with a new JS framework, it's usually not too difficult to get it to integrate with other portions of your favorite front-end stack (CSS/SCSS/LESS/CSS-in-JS, utility libs, etc.).
+
+Intermingling with JavaScript code makes it much more difficult for Elm to type-check & deliver on its promise of "no runtime exceptions", so there's a process of communicating with JavaScript packages via "ports". However, communicating with a JS port can tend to be rather tedious, and I found myself writing a lot of my own logic for things that I likely would have used a utility for had I been working in JS.
+
+I'm a big fan of staying minimal & only using 3rd-party dependencies when you need them, but a beautiful part of the JS ecosystem is that you can consume these packages on NPM when you need to move fast or when you want to isolate a specific concept you're learning (i.e. you only want to learn Vue as a framework so you use Vue Material or Bootstrap so you don't spend all of your precious time styling your components).
+
+### 2. HTML Templating is Little Strange
+
+Everything that I heard from the Elm community said that over time you get used to the HTML syntax, but it never really caught on for me. Here's a quick example of an Elm "template" (or "view" function).
+
+```haskell
+view model =
+  div []
+    [ button [ onClick Decrement ] [ text " - " ]
+    , div [] [ text (toString model) ]
+    , button [ onClick Increment ] [ text " + " ]
+    ]
+```
+
+In the above example, each HTML element is a function that takes two arguments & is named after its' corresponding HTML tag. The first parameter contains a `List` (array) of all the HTML attributes to be applied to the tag. The second parameter contains an array of all the children of the element. The theory behind doing HTML templating this way is that _everything in Elm is simply a function_, but in practice, it just feels a tiny bit clunky to me.
+
+Compare this to something like JSX, which feel much closer to raw HTML.
+
+```jsx
+const view = (model) => (
+	<div>
+		<button onClick={Decrement}> - </button>
+		<div>{model}</div>
+		<button onClick={Increment}> + </button>
+	</div>
+);
+```
+
+Or something like Vue's template syntax, which just builds on top of HTML
+
+```html
+<div>
+	<button v-on:click="Decrement">-</button>
+	<div>{{model}}</div>
+	<button v-on:click="Increment">+</button>
+</div>
+```
+
+In my opinion, both the React & Vue template syntaxes are quite a bit easier to read quickly, although they might not be quite as flexible & composable as Elm's HTML functions.
+
+### 3. Lack of Support From a Major Company
+
+On one hand, I hesitate to even make this a point against Elm as a language. The language should stand or fall on the way that it operates alone (in a perfect world...).
+
+However, what I've found when talking to colleagues is that the primary concern about Elm is due to the fact that it's not supported by a major company. I would venture that the reason I haven't seen too many companies adopt it is that without the big \$\$\$ from a major company, the evolution & support of the language could potentially end abruptly.
+
+The front-end landscape shifts pretty quickly, and keeping a language up-to-date is a full-time job (props to the people currently supporting Elm). Couple that with the fact the compile target (JavaScript) isn't staying still: in fact, JavaScript is moving at breakneck speed, gaining new features & browser APIs every year. Hopefully we will see Elm stick around & continue to keep up-to-date, as it's a really pleasant language to write in.
+
+## Conclusion
+
+I still think that Elm is 100% worth learning &mdash; if you have the time. It's valuable for the way that it forces you to think about programming. What happens if the JSON you recieve from a server doesn't have the key you expect? What if the user's browser fails to give you geolocation data? (Both have been sources of particularly tricky bugs in JS I've worked on in the past year or so).
+
+Elm forces you to handle all your errors, dot all your "t's", cross all your "i's". Even if you don't start using it in the workplace, the benefits from stretching your mind & trying new paradigms are huge.
+
+However, I also know & feel the sentiment of those with reservations towards Elm. It is a different, unfamiliar language to many working in the front-end ecosystem, and the tradeoffs that it makes in favor of type security & runtime safety do add a bit of complexity if you're trying to move quickly or operate with other parts of the front-end ecosystem.
+
+Like what you read? Disagree? Feel free to [tweet at me](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/). Thanks for reading!

--- a/packages/content/writing/three-ways-to-break-focus-state.md
+++ b/packages/content/writing/three-ways-to-break-focus-state.md
@@ -1,0 +1,14 @@
+---
+title: '3 ways everyone breaks their website’s focus state'
+description: Common ways to break your app for anyone using a keyboard.
+
+date: 2019-01-15
+publisher: LogRocket
+link: https://blog.logrocket.com/3-ways-everyone-breaks-their-websites-focus-state-b0d29bdeda11/
+tags:
+  - accessibility
+  - css
+  - html
+---
+
+In this article I look into a few common mistakes I've seen (and done 😱) when dealing with focus state.

--- a/packages/content/writing/trampolines-for-recursion.md
+++ b/packages/content/writing/trampolines-for-recursion.md
@@ -1,0 +1,13 @@
+---
+title: 'Using trampolines to manage large recursive loops in JavaScript'
+description: In this article I talk about a nifty trick for getting around call stack overflows when using recursion in JavaScript.
+
+date: 2018-05-14
+publisher: LogRocket
+link: https://blog.logrocket.com/using-trampolines-to-manage-large-recursive-loops-in-javascript-d8c9db095ae3/
+tags:
+  - javascript
+  - functional-programming
+---
+
+In this article I talk about a nifty trick for getting around call stack overflows when using recursion in JavaScript.

--- a/packages/content/writing/typesafe-errors-in-typescript.md
+++ b/packages/content/writing/typesafe-errors-in-typescript.md
@@ -1,0 +1,154 @@
+---
+title: Leaning into TypeScript for type-safe error handling
+description: You get more out of the type system if you think of the compiler as your friend instead of  a gatekeeper.
+date: 2020-04-12
+draft: false
+image:
+  url: 'pawel-czerwinski-unsplash.jpg'
+  alt: 'Abstract rock pattern with vibrant colors'
+tags:
+  - typescript
+  - exception-handling
+---
+
+Over the past year I've been working on a large TypeScript project, and I'm happy to say I'm now officially on "team TypeScript".
+
+Previously I've felt a little cautious about jumping on the TypeScript hype train for two main reasons:
+
+- **"It's too verbose."** Compared to JavaScript, TypeScript is certainly much more verbose. Other statically typed languages, like Reason and Elm don't require you to write nearly as many type annotations either.
+- **"The type system isn't strong enough."** Using the `any` type lets you break out of type-checking entirely, so the type system is only strong as long as you're diligent enough to add the type annotations correctly. Compare this to Reason and Elm—the other statically-typed languages I've worked in—and you'll see that they both have much stronger type systems.
+
+I've written about both of these before—here's [an article I wrote a while back](https://blog.logrocket.com/what-makes-reasonml-so-great-c2c2fc215ccb/) on why Reason is so cool. I still think Reason is cool, but I'm no longer hesitant about TypeScript.
+
+After working with TypeScript (TS) for a while, I think it has a type system that's _strong enough_ to provide confidence. The verbosity I felt when using TS was more due to unfamiliarity.
+
+I'm a firm believer that when using a static type system you get more out of it by leaning _into_ the type system rather than fighting against the type system. It's best if you think of the compiler as your friend instead of your enemy.
+
+Which brings me to the focus of this article—how we can work _with_ TypeScript to handle errors.
+
+## Why throwing errors isn't type-safe
+
+A very common style of handling errors in JavaScript (and TypeScript) is to `throw` an error. `throw` is built-in to JavaScript—by `throw`ing an `Error` it propagates up the stack until it reaches a `catch` block.
+
+```js
+function throwsError() {
+	throw new Error('😱');
+}
+
+try {
+	throwError();
+} catch (error) {
+	// we have access to the error here.
+}
+```
+
+Using `throw` to handle errors isn't bad—many server frameworks like NestJS and Express use this method since you can use a single `catch` block at the top of your app. This means you're able to handle all errors in your app in a single location—regardless of their point of origin.
+
+In React you can catch errors coming from your components using [`componentDidCatch`](https://reactjs.org/docs/error-boundaries.html) and creating an `ErrorBoundary` component (I'm not too sure about other front-end frameworks since I mostly work in React).
+
+However, just because `throw` is common doesn't mean it's _type-safe_. Anytime you `throw` an error, you need to have a `catch` block to catch it or it could potentially bubble up and crash your app! TypeScript isn't able to infer that your code using `throw` is nested inside a `catch` block so whenever you use `catch` you're relying on developer diligence instead of the type system to make sure your app won't crash on flaky data.
+
+## Using a `Result` type to leverage the type system
+
+So, how can we manage failure and uncertainty in our app in a way that allows the type system to catch potentially unsafe code for us?
+
+I have a custom type that I use to wrap unsafe code, here's what it looks like:
+
+```ts
+type ResultSuccess<T> = { type: 'success'; value: T };
+
+type ResultError = { type: 'error'; error: Error };
+
+type Result<T> = ResultSuccess | ResultError;
+```
+
+The `Result` type is an example of a TypeScript _union type_—it represents something that could be a `ResultSuccess` _or_ a `ResultError`. `ResultSuccess` and `ResultError` both have a `type` property, but other than that the objects are completely different.
+
+Here's what it would look like to have a function that returns a `Result` type.
+
+```ts
+let myFunction = (value: string): Result<number> => {
+	if (value === '0') {
+		return { type: 'error', error: new Error('The value cannot be 0') };
+	}
+
+	return { type: 'success', value };
+};
+```
+
+This example is fairly small—the function doesn't do much more than checking whether the `value` is `0` or not. However, the benefits of a `Result` type become clearer when we slap it on an API request:
+
+```ts
+import axios from 'axios';
+
+let myRequest = async (id: string): Result<User> => {
+	try {
+		let result = await axios.get(`/my-api/users/${id}`);
+		return { type: 'success', value: result.data };
+	} catch (error) {
+		return { type: 'error', error };
+	}
+};
+```
+
+One note about using `axios` for data fetching is that it will automatically `throw` an error if the API returns anything with a 400-level or 500-level response. While this means you don't _have to_ check for successful responses, this opens us up to the danger that an uncaught exception crashes the entire app.
+
+However, if we wrap the `axios` call in a try/catch block, how do we type that? And what if we actually _do_ want to `throw` an error from our failed requests?
+
+When we have our "risky" code return a `Result`, TypeScript is smart enough to force us to check the `Result` type for a successful response _before_ we try to use the value.
+
+```ts
+let fetchDataAndNotify = async () => {
+	let data = await myRequest('@benjamminj');
+
+	if (data.type === 'success') {
+		return `The user's name is ${data.value.name}`;
+	}
+
+	return `There was an error fetching this user.`;
+};
+```
+
+I'll admit, having these types of checks around the codebase isn't the "prettiest" thing in the world. But it's certainly better than having the app randomly crash when data is missing or API requests fail. Fault-tolerance and safety are more valuable than avoiding a couple `if` blocks!
+
+Using `Result` allows us to take a potential runtime error and turn it into a compile-type error:
+
+```ts
+let fetchDataAndNotify = async () => {
+	let data = await myRequest('@benjamminj');
+
+	// This line will be a TS error, since `data.value` doesn't exist on
+	// `ResultError` and we don't know for sure that `data` is a `ResultSuccess`
+	return `The user's name is ${data.value.name}`;
+};
+```
+
+As an added bonus, if you _do_ want to throw an error, the `ResultError` type contains an actual `Error`. This gives you full control over how and when errors get thrown from your app.
+
+```ts
+let renderEssentialData = async () => {
+	let data = await myRequest('@benjamminj');
+
+	if (data.type === 'error') {
+		// If this data is essential to the app, it's better to fail fast than to
+		// show potentially malformed or invalid states.
+		throw data.error;
+	}
+
+	// Do stuff with the data here, TS knows that it's a ResultSuccess type by now.
+};
+```
+
+And that's it! I've been using this approach for most of the API calls coming into the front-end. I'm really happy with how it's turned out on the apps where I've implemented it! Instead of having random crashes, I'm forced time and time again by the compiler to either design error states for missing data or API failures.
+
+## Influences and Prior Art
+
+This pattern isn't something I came up with out of the blue, so I want to highlight a couple key influences I had in discovering this pattern.
+
+One of the key influences for this `Result` interface came from the [`Option` type in Reason](https://reasonml.github.io/docs/en/null-undefined-option). The `Option` type is the way that Reason allows you to deal with nullable data without compromising its type safety. It's fairly similar to the `Maybe` monad in Elm and Haskell if you're a fan of those languages.
+
+Secondly, I've gotten a lot of great TypeScript patterns from [TypeScript Deep Dive](https://basarat.gitbooks.io/typescript/) by [Basarat Ali Syed](https://github.com/basarat). Specifically, his section on [exception handling](https://basarat.gitbook.io/typescript/type-system/exceptions#you-dont-have-to-throw-an-error) was influential in me using this `Result` pattern.
+
+Lastly, I wanted to reiterate that that the best solutions with TypeScript typically come from leaning _into_ the type system rather than fighting against it. This `Result` type came out of desiring to find a way to force my team (myself included) check for error states rather than optimistically trusting that certain functions (primarily API requests) will always return successfully.
+
+If you enjoyed this, please let me know on my [Twitter](https://twitter.com/benjamminj) or [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) with a share! If you found any errors or bugs in this article let me know or submit a pull request to update this article.

--- a/packages/content/writing/typescript-async-function.md
+++ b/packages/content/writing/typescript-async-function.md
@@ -1,0 +1,119 @@
+---
+title: Type definitions for async functions in TypeScript
+description: Understanding how JavaScript async functions work under the hood helps us know exactly how to type them in TypeScript.
+date: 2020-04-22
+draft: false
+image:
+  url: 'photo-boards-shapes.jpg'
+  alt: 'Abstract wall decor in blue, yellow and brown'
+tags:
+  - typescript
+  - promises
+  - async
+---
+
+One of the things that tripped me up when I first started using TypeScript was how to write type definitions for async functions.
+
+Async/await syntax were added to ECMAScript in 2017 (or ES8), and it's incredibly useful for dealing with asynchronous code. If you're unfamiliar with async/await, this is what the syntax looks like:
+
+```js
+async function fetchData(id) {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+}
+```
+
+Or, if you prefer using arrow functions, the above function's equivalent would look like this:
+
+```js
+const fetchData = async (id) => {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+};
+```
+
+Changing a regular function into an async function happens just by using the `async` keyword in front of the function declaration. By doing this, we're able to use the `await` keyword to simply have our function pause execution until whatever we're `await`ing is resolved.
+
+Before we get to writing TypeScript definitions, it's important that we have a thorough understanding of how JavaScript [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) work. The reason for this is that async/await is just a pretty syntax for promises! So when we get around to type definitions, typing an async function is exactly the same as typing a function that returns a promise.
+
+Our sample function _without async/await_ would look like this:
+
+```js
+function fetchData(id) {
+	// resolves with an array of users
+	return fetch(`https://example.com/users/${id}`).then((result) => result.json());
+}
+```
+
+This function and the async/await version are _the same_ in terms of how they behave and what type of values they return. The difference is purely in the syntax.
+
+_💬 **A quick note:** since async/await is just a pretty syntax for promises, you might find that in some cases using the regular promise syntax feels cleaner. This is ok—it's not wrong to use async/await and promises interchangeably based on the situation. I personally think our example lends itself more to promises since there's only a single `.then` being chained._
+
+## Now to the type definitions!
+
+Armed with the knowledge that an async function is a fancy syntax for a function that returns a promise, we can move on to writing the type definitions.
+
+TypeScript has a built in `Promise` type we can use to describe promises—it's a [generic type](https://www.typescriptlang.org/docs/handbook/generics.html) so we'll pass in the _type_ that the promise resolves with.
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+// This type describes a promise resolving with an array of user objects.
+type UsersPromise = Promise<User[]>;
+```
+
+Once we've identified how to wrap our `User` interface in the `Promise` type all that's left to do is attach it to our function and add the other type annotations:
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+async function fetchData(id: string): Promise<User[]> {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+}
+```
+
+We give `id` a type of `string` so that TypeScript knows how to infer its type, and then just attach the `Promise<User[]>` to `fetchData` as the return value. This tells TypeScript that the function operates asynchronously and anyone using it will need to either `await` it or use `fetchData(id).then(users => {})` to actually make use of the fetched `users` data.
+
+If you prefer to use [type aliases](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-aliases) for your functions, you can use the same TypeScript syntax along with declaring the function slightly differently to type the async function with a type alias:
+
+```ts
+interface User {
+	id: string;
+	name: string;
+}
+
+// Type alias
+type FetchData = (id: string) => Promise<User[]>;
+
+const fetchData: FetchData = async (id) => {
+	const result = await fetch(`https://example.com/users/${id}`);
+	const json = result.json();
+
+	// json is an array of users
+	return json;
+};
+```
+
+This can be especially useful to decrease verbosity if the async function you're typing has multiple or complex parameters.
+
+---
+
+Thanks for reading—I hope that this was helpful to you in figuring out how to still use async/await syntax while giving TypeScript enough info to properly infer the shapes of the data your async functions are returning.
+
+As always, feel free to hit me up on my [Twitter](https://twitter.com/benjamminj) or [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) with any thoughts. If you found a typo in this article or have some feedback for improvement please feel free to [sumbit a pull request](https://github.com/benjamminj/portfolio).

--- a/packages/content/writing/typescript-generics.md
+++ b/packages/content/writing/typescript-generics.md
@@ -1,0 +1,273 @@
+---
+title: TypeScript generics
+date: 2020-09-11
+lastUpdated: 2020-09-12
+tags:
+  - typescript
+---
+
+## tl;dr 🙃
+
+TypeScript generics create reusable type definitions by letting you make some parts configurable. They're like **function parameters for your types.**
+
+## Overview: basic generic types 🧱
+
+Generic types can be difficult to wrap your mind around, especially when you're new to TypeScript. They're certainly tougher than type annotations (`const a: number = 1`) or interfaces.
+
+Part of this is because generic types are **abstract types**.
+
+Their syntax might also be somewhat unfamiliar—especially if you're coming from JavaScript. You might be wondering what these `<>` brackets are doing all over the code. 😱
+
+To dive into generic types, let's start with a couple of type definitions. Imagine we have interfaces for a `User` and a `Post` in a blogging app.
+
+```ts
+interface User {
+	id: string;
+	name: string;
+	email: string;
+	phoneNumber: string;
+}
+
+interface Post {
+	id: string;
+	userId: string;
+	title: string;
+	body: string;
+}
+```
+
+Now, let's think about data fetching in our fictional blogging application. We probably have some API endpoints that return paginated lists of data. Something like `/api/users` and `/api/:userId/posts`.
+
+The interfaces for the paginated API response could look something like this.
+
+```ts
+interface UsersListResponse {
+	// Array of User objects
+	data: User[];
+	page: number;
+	totalPages: number;
+	totalCount: number;
+	perPage: number;
+}
+
+interface PostsListResponse {
+	// Array of Post objects
+	data: Post[];
+	page: number;
+	totalPages: number;
+	totalCount: number;
+	perPage: number;
+}
+```
+
+You'll notice that the `UsersListResponse` and the `PostsListResponse` are nearly identical. The only thing that isn't copy-pasta is the `data` property—in one it's a `User` array, in the other a `Post` array.
+
+With two interfaces it's not difficult to keep them synced. But as our applications grow we'll get more interfaces and maintaining the _interfaces_ gets progressively more difficult.
+
+TypeScript generics let us create a single source of truth for _types_.
+
+They're function paramaters for type definitions.
+
+With generics, we can rewrite `UsersListResponse` and `PostsListResponse` to look like this.
+
+```ts
+interface PaginatedResponse<T> {
+	data: T[];
+	page: number;
+	totalPages: number;
+	totalCount: number;
+	perPage: number;
+}
+
+type UsersListResponse = PaginatedResponse<User>;
+type PostsListResponse = PaginatedResponse<Post>;
+```
+
+The _generic_ portion is the `<T>` in `PaginatedResponse<T>`—this sets up a type "parameter" named `T`. We can then use `T` inside our interface to configure the _type_ of certain properties.
+
+In this case we want to configure `data` as a `T[]` since it's an array of whatever type `T` is.
+
+_You can name `T` anything you like. Using `T`, `U`, and `K` as generic parameter names is a convention you'll see a lot in TypeScript code—especially for simple interfaces. Think of `T` like using `i` in a `for` loop._
+
+Then, to create our two interfaces from before we can drop the `User` and `Post` types into the `<>` brackets on `PaginatedResponse`. So we end up with the exact same interface as before by doing `PaginatedResponse<User>`.
+
+Leveraging these generic types allows us to easily respond to changes within our codebase in a type safe. For example, what if we added a new type of `Label` to the system? This is all we'd need on the TypeScript front.
+
+```ts
+interface Label {
+	id: string;
+	name: string;
+	color: string;
+}
+
+type LabelsListData = PaginatedResponse<Label>;
+```
+
+## A deeper dive: advanced generic types
+
+I hope this small example has shown some of the ways that generic types can help in making your TypeScript code less verbose and more elegant!
+
+The examples above cover some basic usage of generic types. In this section we'll dive a little deeper and look at some extra "tricks" to make our generics even more useful. 💪
+
+### Constrained generic types
+
+Sometimes we want to provide a generic type, but we don't want it to allow any type as a parameter. Instead, we want to limit the parameter to a few approved types.
+
+```ts
+interface IndividualResponse<T extends object> {
+	data: T;
+}
+
+// ✅ This compiles correctly.
+type UserByIdResponse = IndividualResponse<User>;
+
+// 🚨 This gives the following compiler error:
+// "Type 'number' does not satisfy the constraint 'object'."
+type NumberResponse = IndividualResponse<number>;
+```
+
+The type constraint is that `extends object` bit. I like to think of it as similar to typing a function argument.
+
+```ts
+const add = (a: number, b: number) => a + b;
+```
+
+In this `add` function TypeScript doesn't care about what values we pass into `a` and `b`. But it does throw compiler errors if those values aren't `number` types. In a similar way our `IndividualResponse` type will allow any type as a parameter as long as it is an `object`. Since `number` isn't an `object` type, we get a compiler error.
+
+### Default generic types
+
+In the same way that we can provide a type constraint to an interface, we can also provide a default type when we're creating generics.
+
+```ts
+interface IndividualResponse<T = object> {
+	data: object;
+}
+
+const response: IndividualResponse = someData;
+const numberResponse: IndividualResponse<number> = someOtherData;
+
+// This will have a a type of "object"
+response.data;
+
+// This will have a a type of "number"
+numberResponse.data;
+```
+
+It's usually a good idea to add some default type if you're planning on having your interfaces get reused a lot (unless you can infer the type from a function parameter—we'll get to that next).
+
+Lots of libraries use this approach in their type definitions because it gives you some default type safety out of the box without forcing you to use the `<>` syntax every time you use their API. And then if you want better type checking you can use the `<>` and pass your types in. Best of both worlds! 🔥
+
+### Inferring generics from function parameters 🤯
+
+One of the most powerful ways to use TypeScript generics is to infer their type from function parameters.
+
+Consider this simplified version of the `Array.prototype.filter` function.
+
+```ts
+const filter = <T = unknown>(array: T[], validate: (value: T, index: number) => boolean): T[] => {
+	const newArray = [];
+	for (let i = 0; i < array.length; i++) {
+		const value = array[i];
+		const isValid = validate(value, i);
+
+		if (isValid) {
+			newArray.push(value);
+		}
+	}
+
+	return newArray;
+};
+
+const above3 = filter([1, 2, 3, 4, 5], (number) => number > 3); // Returns [4, 5]
+
+above3; // Type is a "number[]"
+```
+
+This is way more confusing on the syntax front. Let's break down what's going on in `filter`.
+
+First, we have `<T = unknown>` in front of the parentheses. This has the same purpose as `interface Name<T>`—this is just the syntax for adding a generic to a function.
+
+```ts
+const filter = <T = unknown>(array, validate) => {
+	// function body
+};
+```
+
+Next, let's look at the `array` parameter to `filter`.
+
+```ts
+const filter = <T = unknown>(array: T[], validate) => {
+	// function body
+};
+```
+
+This says that the argument we pass as `array` should be our dynamic `T` type.
+
+This alone is actually enough for TypeScript to **infer** that when we call `filter([1, 2, 3, 4], value => value > 3)` that `array` will be a `number[]` and not something else!
+
+But we can go a few steps further.
+
+Let's take a look at the `validate` argument.
+
+```ts
+const filter = <T = unknown>(array: T[], validate: (value: T, index: number) => boolean) => {
+	// function body
+};
+```
+
+We can also use `T` when typing our `validate` function to say that _whatever the type of the array is, the "value" should be the same type_.
+
+This means that when we do `filter([1, 2, 3, 4], value => value > 3)` the compiler actually knows that `value => value > 3` should be a **number**. If we tried to do `value => value.toUpperCase()` we'd get a compiler error, since `toUpperCase` only exists on `string` types.
+
+Finally, we add `T[]` as the return type of the function.
+
+```ts
+const filter = <T = unknown>(array: T[], validate: (value: T, index: number) => boolean): T[] => {
+	// function body
+};
+```
+
+This seems like crazy rocket science. Maybe even over-the-top, wouldn't it just be easier to use `any` types?
+
+But it all comes together when we actually put our `filter` function into action.
+
+```ts
+const above3 = filter([1, 2, 3, 4, 5], (value) => value > 3);
+```
+
+You'll notice that this **doesn't have any types added**. It's plain JavaScript.
+
+But if we look at the type of `above3` in an IDE we'll see it's a `number[]`. In VSCode you can hover over the variable and you'll see its type. Looking at `value` also shows it's a `number` too. 🔥
+
+We gave enough hints to the compiler that all it needed was `[1, 2, 3, 4, 5]` to figure out all of the type definitions.
+
+---
+
+Defining generic types this way can be difficult to get right. Chances are you'll struggle with the compiler your first few times.
+
+But the reward is type safety without syntax clutter bleeding into other parts of your app. You drastically cut down on verbosity without sacrificing on type safety.
+
+Using generic types this way lets you hide the verbose TypeScript typings inside the function itself. That way you don't force others to manually provide types whenever they're using `filter`.
+
+## A warning about generics 🚧
+
+As you can see, TypeScript generics can range from simple to ridiculously complex. It's easy for them to get out of hand if you're not careful.
+
+Don't go overboard when creating generic types—a little duplication is preferable to overengineering.
+
+TypeScript code is just a tool to help you write JavaScript—it's all going to get compiled down into JavaScript when you ship it. The type definitions are for _developers only_.
+
+Good developer experience does matter, but it doesn't come at the expense of shipping a good user experience. The last thing you want to do is spend a bunch of time on TypeScript typings and ship nothing.
+
+Personally, I cap my attempt at around 30 minutes. That's usually enough for me to get it working. But if I still can't get the generic type right I add `unknown` or `any` and continue with my work. Sometimes I'll circle back around to it, sometimes I won't. 🤷‍♀️
+
+If getting generic types is difficult at first, keep trying! Like all programming concepts, it gets easier with practice.
+
+---
+
+## Resources
+
+For some further reading on TypeScript generics, check out these resources. 🤓
+
+- [Basarat's TypeScript Deep Dive](https://basarat.gitbook.io/typescript/type-system/generics)
+- [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/generics.html#using-type-parameters-in-generic-constraints)

--- a/packages/content/writing/use-debounced-value.md
+++ b/packages/content/writing/use-debounced-value.md
@@ -1,0 +1,132 @@
+---
+title: useDebouncedValue
+subtitle: Create a debounced copy of an input value.
+date: 2020-12-22
+tags:
+  - react
+  - typescript
+  - recipes
+---
+
+```tsx
+import { useState, useEffect } from 'react';
+
+export const useDebouncedValue = <T extends any>(input: T, delay = 0) => {
+	const [value, setValue] = useState(input);
+
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			setValue(input);
+		}, delay);
+
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, [input, delay]);
+
+	return value;
+};
+```
+
+## Context
+
+When building UIs it's nice to respond to user input _immediately_. In React it's generally ok to call `setState` multiple times in quick succession since [React batches state updates](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous).
+
+However, you _don't_ want to rapidly update a state value if you've got a `useEffect` wired up to it. This could have disastrous results (like DDoSing your API or terrible render performance). 😱
+
+This hook creates a carbon copy of the original state value. The only difference is that the `useDebouncedValue` doesn't update _until its dependency stops updating_.
+
+This makes it much safer to use as a dependency for `useEffect` if your state is rapidly changing.
+
+While debouncing the `fetch` function (or any function called from within `useEffect`) achieves a similar effect, I think debouncing the _value_ results in cleaner logic. Since you trigger an effect whenever dependencies change, you debounce the effect by changing dependencies less. Overall, it feels more inline with React's data flow and the way that `useEffect` works.
+
+## Usage
+
+```tsx
+import { useEffect, useState } from 'react';
+import { useDebouncedValue } from './useDebouncedValue';
+
+export const Component = () => {
+	const [posts, setPosts] = useState([]);
+	const [search, setValue] = useState('');
+	const debouncedValue = useDebouncedValue(search);
+
+	useEffect(() => {
+		fetch(`https://jsonplaceholder.typicode.com/posts?search=${debouncedValue}`)
+			.then((res) => res.json())
+			.then((posts) => setPosts(posts))
+			.catch(() => setPosts([]));
+	}, [debouncedValue]);
+
+	return (
+		<div>
+			<label>
+				Search
+				<input name="search" value={search} onChange={(ev) => setValue(ev.target.value)} />
+			</label>
+
+			<div>{posts.length} posts found</div>
+		</div>
+	);
+};
+```
+
+## Tests
+
+```tsx
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useDebouncedValue } from './useDebouncedValue';
+
+jest.useFakeTimers();
+
+test('should return the first value immediately', () => {
+	let value = 1;
+	const { result } = renderHook(() => useDebouncedValue(value));
+	expect(result.current).toEqual(1);
+});
+
+test('should not update the value immediately after a change', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => useDebouncedValue(value));
+	expect(result.current).toEqual(1);
+
+	value = 2;
+	rerender();
+	expect(result.current).toEqual(1);
+});
+
+test('should update the value after the delay time', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => useDebouncedValue(value, 100));
+	expect(result.current).toEqual(1);
+
+	value = 2;
+	rerender();
+	jest.advanceTimersByTime(99);
+	expect(result.current).toEqual(1);
+
+	act(() => {
+		jest.advanceTimersByTime(1);
+	});
+	expect(result.current).toEqual(2);
+});
+
+test('should default to a delay of 0', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => useDebouncedValue(value));
+	expect(result.current).toEqual(1);
+
+	value = 2;
+	rerender();
+	act(() => {
+		// Just run the next tick of the call stack.
+		jest.advanceTimersByTime(0);
+	});
+	expect(result.current).toEqual(2);
+});
+```
+
+## Influences and prior art
+
+- **[usehooks.com](https://usehooks.com/useDebounce/)**: I mostly lifted my `useDebouncedValue` function from here. It's not a 100% copy-pasta though: I've renamed a few things, added my own comments, added some tests and ported it to TypeScript.
+- **[`useDeferredValue`](https://reactjs.org/docs/concurrent-mode-reference.html#usedeferredvalue)**: This is built-in to React's concurrent mode and will only update the given value after a timeout period. This hook is a big reason why I think that a `useDebouncedValue` hook feels inline with React's data flow. I might not even need `useDebouncedValue` once concurrent mode is stable! 😅

--- a/packages/content/writing/use-previous.md
+++ b/packages/content/writing/use-previous.md
@@ -1,0 +1,81 @@
+---
+title: usePrevious
+subtitle: Store a reference to the value from the last render.
+date: 2021-02-02T00:00:00.000Z
+tags:
+  - react
+  - hooks
+  - typescript
+  - recipes
+---
+
+```tsx
+import { useEffect, useRef } from 'react';
+
+/**
+ * Stores a reference to the previously rendered value.
+ *
+ * This can be used to execute dependency checks to compare whether a single
+ * dependency has changed.
+ *
+ * During the first render, `undefined` will be returned. Following renders will
+ * return a value.
+ */
+export const usePrevious = <T extends unknown>(value: T) => {
+	const ref = useRef<T | undefined>();
+
+	useEffect(() => {
+		ref.current = value;
+	}, [value]);
+
+	return ref.current;
+};
+```
+
+## Context
+
+This hook can be really useful when you want to bail out of a `useEffect` early. Or if you have a `useEffect` with a few dependencies but you want to wait until a certain one has changed.
+
+Technically, this hooks is kinda a "hack", I feel like it doesn't line up perfectly with React's data flow and programming model for hooks. I _think_ in most cases there's a "better" way—something like flipping a flag based on the dependency that needs to update. But I've found myself reaching for `usePrevious` in most of medium-to-large applications I've built the last few years.
+
+## How it works
+
+`usePrevious` starts of by setting up a `useRef` in the first render. This will initially be `undefined` (since in the first render there isn't a previous value).
+
+Secondly, we set up a `useEffect` to sync that `ref` after each render cycle. [`useEffect` runs _after_ each render](https://reactjs.org/docs/hooks-reference.html#useeffect) is committed to the screen, so in the _next_ render cycle, you'll have the _previous_ render cycle's value stored in `ref.current`
+
+## Usage
+
+```tsx
+const Component = ({ query, filter }) => {
+	const previousQuery = usePrevious(query);
+
+	useEffect(() => {
+		// If the query didn't change, bail out early
+		if (query !== previousQuery) return;
+
+		// Otherwise, continue fetching as usual.
+		fetchData(query, filter);
+	}, [query, previousQuery, filter]);
+
+	// render data
+};
+```
+
+## Tests
+
+```tsx
+import { renderHook } from '@testing-library/react-hooks';
+import { usePrevious } from './usePrevious';
+
+test('should return the value of the previous render', () => {
+	let value = 1;
+	const { result, rerender } = renderHook(() => usePrevious(value));
+	expect(result.current).toEqual(undefined);
+	value = 2;
+	rerender();
+	expect(result.current).toEqual(1);
+	rerender();
+	expect(result.current).toEqual(2);
+});
+```

--- a/packages/content/writing/using-rem-based-media-queries.md
+++ b/packages/content/writing/using-rem-based-media-queries.md
@@ -1,0 +1,26 @@
+---
+title: Using rem-based media queries
+date: 2020-09-29
+tags:
+  - css
+---
+
+One of my favorite CSS "tricks" is the `rem`-based media query:
+
+```css
+@media screen and (min-width: 48rem) {
+	/*  Styles for tablets and above */
+}
+```
+
+Instead of using pixels for the width of the screen, you can define the width of the screen using `rem` units. One key benefit to this is **accessibility**.
+
+I often bump my font size up larger than the default. While I can see fine without it I find the larger font sizes relaxing on my eyes.
+
+Writing media queries like this allows you to scale layout with a user's font-sizing preferences. So if your user has a tablet screen (~768px) and a 150% font size, they would see the _mobile_ layout. This mobile layout is more helpful if your font is taking up a significant portion of your tablet-sized screen width.
+
+Lastly, a couple caveats to this approach. First, if you're actually changing the `font-size` on the `html` element, this might not be for you. Personally, I've never had to actually change the root `font-size` dynamically so this is rarely a concern for me.
+
+Second, `rem`-based media queries can take a while to get used to. You'll have to do some math if you need to figure out standard screen sizes. For example, `768px` divided by a root font-size of `16` results in `48rem`. That said, I think the benefits (accessibility) outweigh the cost (unfamiliarity).
+
+Thanks for reading! Let me know if you enjoyed this—you can reach out to me on [Twitter](https://twitter.com/benjamminj) or connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (make sure to mention this post if you do connect!)

--- a/packages/content/writing/what-makes-reasonml-so-great.md
+++ b/packages/content/writing/what-makes-reasonml-so-great.md
@@ -1,0 +1,14 @@
+---
+title: 'What makes ReasonML so great?'
+description: As it turns out, quite a bit.
+
+date: 2018-09-10
+publisher: LogRocket
+link: https://blog.logrocket.com/what-makes-reasonml-so-great-c2c2fc215ccb/
+tags:
+  - reason
+  - functional-programming
+  - javascript
+---
+
+In this article I do an intro for an exciting programming language coming out of Facebook—Reason (also known as ReasonML).

--- a/packages/content/writing/why-keeping-a-code-journal-will-make-you-a-better-developer.md
+++ b/packages/content/writing/why-keeping-a-code-journal-will-make-you-a-better-developer.md
@@ -1,0 +1,48 @@
+---
+title: Why Keeping a Code Journal Will Help You Become a Better Developer
+description: Even if you’re not journaling frequently, reflection is one of the best ways to internalize the things that you learn.
+date: 2017-10-24
+image:
+  url: 'blog-img-journal.jpg'
+  alt: Journal and pen lying on a table
+---
+
+I’ll be honest — I straight-up stole this idea from [Ryan McDermott](https://medium.com/@ryansworks) after hearing him talk about keeping a code journal on [JS Jabber](https://devchat.tv/js-jabber/clean-code-javascript-with-ryan-mcdermott) and how it helped him write better code over time.
+
+Over the past 3–4 months I’ve been keeping a code journal of my own, and I can personally vouch for the benefits that come from taking a couple minutes to reflect on the code I read/wrote. Like any habit, it takes some time to form, especially when you’ve got real work to do — and I still miss days here and there. But I wanted to share a few of the benefits that I’ve noticed.
+
+## Keeping a Code Journal Forces You to Identify Code Smells.
+
+It’s truly rare to see a perfect codebase. If you’re working as a developer, chances are you’re spending most of your day reading code, and there’s bound to be something the code you read that’s less than perfect.
+
+Most of the time, if it’s something that super hard to understand, you either spend a couple extra minutes reading/understanding the code, or you go and ask the developer who wrote it.
+
+And then you go about solving the problem you were working on, and in a few weeks, you more or less forgot about the smelly code you read on that one occasion (after all, you’re on to something completely else by then).
+
+Furthermore, sometimes you know intuitively that something isn’t clean or easy to read, but you’re not exactly sure why.
+
+Both of these scenarios are a perfect case for keeping a code journal. By virtue of documenting what you read you’re forced to process why it was less than ideal (this has the side benefit of also exposing good alternatives), and you now have a written record that you can reference later. Win-Win.
+
+## Keeping a Code Journal Helps You Identify Clean Code.
+
+Your reflections shouldn’t be all negativity though. Chances are you work with a bunch of smart people (I know I do!) that are capable of writing beautiful, clean, readable code.
+
+Just like when noting code smells, sometimes you don’t intuitively know why the code you read is amazing, and chances are you’re not gonna remember it in a few weeks. Taking the time to process what was great about it will help you internalize the concepts.
+
+## Keeping a Code Journal Helps You With Personal Branding.
+
+One of the awesome side effects of writing down all of the clean/messy code you read is that you’re basically writing outlines for blog posts. If you’re anything like me, consistency and finding good material to write on are two of the hardest things.
+
+I’ll be honest, consistency with writing hasn’t been my strong suit, and I’m not gonna dive into that right now 😎. Keeping a code journal isn’t going to help you sit down and actually write articles. That’s more on the discipline side of things.
+
+However, keeping a code journal can help with inspiration. Think of it this way—if you write down one entry every other day (see, even not that consistently!), at the end of a week you’d have 3–4 ideas that you can look at for inspiration. And furthermore, you’ve already written a basic outline.
+
+## Conclusion
+
+Even if you’re not writing entries frequently, reflection is one of the best ways to internalize the things that you learn.
+
+Another thing to note. I’ve just been using a git repo with a bunch of markdown files. I find it really easy to go write something down and get back to work this way. But you don’t have to do it the way that I do — do whatever helps you best!
+
+What about you? Are there any specific things that you do to internalize the things that you encounter in your day-to-day learning?
+
+Thanks a bunch for reading. Let’s connect—feel free to connect with me on [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) or tweet at me on [Twitter](https://twitter.com/benjamminj).

--- a/packages/content/writing/why-ssr.md
+++ b/packages/content/writing/why-ssr.md
@@ -1,0 +1,87 @@
+---
+title: Why SSR
+description: Server-rendering is more than just SEO and speed
+date: 2022-05-01
+tags:
+  - http
+  - software-engineering
+  - fundamentals
+---
+
+A common claim I've heard in recent years goes like this: "We don't need SEO because our app is B2B...so server-rendering (SSR) is overkill".
+
+However, there's many reasons to consider SSR as a good-enough default for most applications. Many apps are a blend of SSR and client-side fetching, and some apps _aren't_ a good fit for SSR.
+
+That said, many apps (most apps?) gain many benefits from leaning in to the server-rendered paradigm. Here's some additional reasons to adopt server-rendering beyond Lighthouse scores.
+
+## Server-rendering yields a simpler mental model
+
+If you _exclusively_ server-render (no client-side JS), every action follows the same workflow:
+
+1. Request enters your server through a HTTP request.
+2. Server processes the request and responds, usually HTML or a redirect.
+3. HTML document is sent to the user.
+
+Even though your app now runs in two environments (browser & server), you've simplified the data flow. Now you can focus on interaction and pizazz on the client-side and let the server do the heavy-lifting in regards to data.
+
+Going purely client-side usually introduces some additional workflows (examples are just from the React ecosystem). These aren't exclusive to client-side rendering, but they often accompany a more client-centric model.
+
+- Handling request waterfalls (querying per component, [React Suspense](https://reactjs.org/docs/react-api.html#reactsuspense)).
+- Caching API responses in-memory in JS ([Apollo](https://www.apollographql.com/docs/react), [React-Query](https://react-query.tanstack.com/)).
+- Updating application state without any data fetching ([Redux](https://redux.js.org/), [React State](https://reactjs.org/docs/state-and-lifecycle.html)).
+- Form libraries ([Formik](https://formik.org/docs/overview), [React-Hook-Form](https://react-hook-form.com/get-started), [Final Form](https://final-form.org/docs/final-form/getting-started))
+
+Most apps will be a blend of server-side and client-side patterns, but leaning entirely on client-side approaches may actually make things more complicated.
+
+## Speed is good for everyone.
+
+Fast apps are good on high-speed internet, too. Trust me, your enterprise users will appreciate that _your app_ isn't the one tanking their productivity with slow interactions.
+
+_(Also, with remote working, you can't assume that enterprise users have a high-speed connection anymore)_
+
+While SSR doesn't guarantee speed, it gives you fast defaults, and keeps the door open for future optimization.
+
+## Easier to optimize.
+
+You have no control over your user's device, browser, or internet bandwidth. In contrast, you 100% have the ability to make your server _fast_.
+
+Optimizing client-side apps often boils down to: A) fetch less often, B) optimize asset loading ([PRPL pattern](https://web.dev/apply-instant-loading-with-prpl/)), and C) [don't block the main thread](https://web.dev/mainthread-work-breakdown/). So once you've done all 3 of those you're completely at the mercy of your users' internet connections and device specs.
+
+When your server hsa long response times you have many more options to speed it up. You can optimize the infrastructure (scale vertically/horizontally, multi-region, edge, etc), add caching (CDNs, key-value stores, `Cache-Control` headers) or fix slow code paths (your server or upstream services).
+
+You're able to pick the optimization that makes the most sense at any given time, rather than hitting a wall.
+
+As an added benefit you get some of the client-side optimizations "for free" when you lean in to the server-centric model. Like fetching less via `Cache-Control` headers and keeping the main thread clear (since your server is doing the heavy lifting)
+
+## Server-rendered HTML is probably more accessible.
+
+SSR does not guarantee accessible HTML interfaces. That's up to you, the developer.
+
+However.
+
+HTML forms are _way_ easier to do when you have server-rendering. And if your HTML form works without JavaScript it has a much higher chance of being more accessible than 90% of the JS-only SPA forms out there.
+
+Turns out screen readers are great at reading HTML documents.
+
+## You can have your cake and eat it, too.
+
+SSR might not be able to deliver the 100% polished experience your users expect. You may (probably) want to use a JS framework to build components and structure your UI.
+
+Good news! Most JS frameworks support server-rendering with minimal configuration ([Next.js](https://nextjs.org/), [Remix](https://remix.run/), [SvelteKit](https://kit.svelte.dev/), [NuxtJS](https://nuxtjs.org/), etc).
+
+So you can get all the benefits of server-rendering, while also being able to write client-side JS to power those smooth, snazzy UXs your users have come to expect.
+
+Better yet, running client-side JS becomes an enhancement rather than _required_.
+
+---
+
+## Conclusion
+
+Server-rendering provides a variety of benefits over the fully client-rendered SPAs of today. With modern JS frameworks, you can easily adopt a server-rendered model without having to give up JS on the frontend. Finally, while SSR comes with _some_ complexity, it makes a number of things simpler, namely data fetching, form handling, and optimization.
+
+Have comments or concerns? Loved what you read? I deliberately don't have comments on my blog, so please hit me up on [Twitter](https://twitter.com/benjamminj)!
+
+## Further Reading
+
+- [This thread on Twitter](https://twitter.com/gortok/status/1519361629896552449)
+- [Remix docs](https://remix.run/docs/en/v1/pages/philosophy#serverclient-model)

--- a/packages/content/writing/writing-a-memoize-function-from-scratch.md
+++ b/packages/content/writing/writing-a-memoize-function-from-scratch.md
@@ -1,0 +1,356 @@
+---
+title: Writing a memoize function from scratch
+date: 2020-10-14
+tags:
+  - javascript
+  - from-scratch
+---
+
+## Intro
+
+In this tutorial we'll build our own `memoize` function from scratch.
+
+You might be (or might not be!) familiar with the term "memoize". To give a quick **tl;dr**, "memoize" is kinda a fancy word for "cache". Or to put it a different way, memoizing something is a way of adding caching to it.
+
+When we "memoize" something we cache the results of a function based on its arguments. This can be useful when you have a function that's very performance-intensive.
+
+Chances are you don't need to write your own memoization function for working in most codebases. If you're a `lodash` user, there's `_.memoize`. I've also used `memoize-one` in the past.
+
+But reimplementing things from scratch has other benefits—it's helpful for me when I want to solidify my knowledge of a concept. So here we go, here's `memoize` from scratch!
+
+## The "specs"
+
+Before we dive right in on coding our `memoize` function, let's take a moment and draw up some specifications.
+
+This is how we want `memoize` to look and behave:
+
+```js highlight-lines=3,4
+const sumBelow = memoize(someReallyExpensiveFunction);
+
+// returns `499999999067109000` after delay
+sumBelow(1e9);
+// returns `1999999998067114000` after delay
+sumBelow(2e9);
+
+// immediately returns `499999999067109000`
+sumBelow(1e9);
+```
+
+To further flesh out our "acceptance criteria", here's the things that `memoize` needs to do:
+
+- `memoize` needs to accept a function as an argument
+- `memoize` needs to return a _new_ function that can be used with the same arguments as the original function.
+- When the memoized function is called, it will run the original function.
+- However, **if the memoized function** is called again with the same arguments as a previous call, the result of the first call will be returned **immediately**.
+
+## Writing the function
+
+Alright, let's dive into the code for our `memoize` function.
+
+First, we'll need to set up `memoize` as a function that accepts a function as an argument. (If you're curious, these are often referred to as [higher-order functions](https://medium.com/javascript-scene/higher-order-functions-composing-software-5365cf2cbe99)).
+
+For now, we'll just have `memoize` call the original function with the arguments that were passed to it.
+
+```js
+const memoize = (fn) => {
+	return (...args) => {
+		const result = fn(...args);
+		return result;
+	};
+};
+```
+
+As we go through this tutorial we can use the following code to test whether our memoize function is working:
+
+```js
+// ...memoize function up above
+
+const sumBelow = (limit) => {
+	const sum = 0;
+
+	for (var i = 1; i < limit; i++) {
+		sum += i;
+	}
+
+	return sum;
+};
+
+const memoSumBelow = memoize(sumBelow);
+
+// Returns after a slight delay
+memoSumBelow(1e6);
+// Also returns after a small delay
+memoSumBelow(2e6);
+
+// Should return immediately!
+memoSumBelow(1e6);
+```
+
+If we run this with our current `memoize` function, we'll see that `memoSumBelow` returns the **correct** value each time, but it doesn't return immediately on the third call (the second one with `1e6`).
+
+Let's add a cache of calls to `memoize` so we can make that third call return instantly ⚡️
+
+We'll start by just setting up the cache. We'll use a JavaScript `Map` to store the results.
+
+```js
+const memoize = (fn) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const result = fn(...args);
+		return result;
+	};
+};
+```
+
+It's important that `const cache` is **outside** of the function that we `return`. (FYI, this is referred to as a [closure](https://whatthefuck.is/closure) if you're interested).
+
+Next, we'll want to create a cache key and put the result of `fn(...args)` in our newly created cache. For now we'll use the first argument as a cache key.
+
+```js
+const memoize = (fn) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = args[0];
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+Now there's one thing left to do—we check the cache to see whether the key exists. If it does, we can grab the item out of the cache instead of running `fn`. If it doesn't, we run `fn(...args)` and cache the result for next time.
+
+```js
+const memoize = (fn) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = args[0];
+
+		if (cache.has(cacheKey)) {
+			return cache.get(cacheKey);
+		}
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+## Bonus: writing unit tests 🤓
+
+Let's write some tests for our `memoize` function. I'll be using [Jest](https://jestjs.io/) in these examples.
+
+Before, let's take a step back and brainstorm about the things we _want to test_. We can use our `memoize` specifications that we wrote earlier along with `test.todo`.
+
+```js
+// memoize.test.js
+
+test.todo('should run the function if it has not been called with the same arguments');
+
+test.todo('should return a cached result if the function has been called with the same arguments');
+```
+
+In the first test, we'll run our memoized function with arguments that it has _not been called with_. We'll then verify that the underlying `fn` argument got called correctly.
+
+First, let's remove `test.todo` and replace it with an actual test. At the top of our test we'll create a new mock function using `jest.fn()`.
+
+In this case, we don't need something complicated or performance-intensive—we're just testing that the function gets called, so a simple `plus1` function will do. We'll pass it into `memoize`.
+
+```js
+// memoize.test.js
+
+test('should run the function if it has not been called with the same arguments', () => {
+	const plus1 = jest.fn();
+	const memoizedFn = memoize(plus1);
+});
+```
+
+> _If you're familiar with the [Arrange-Act-Assert pattern](https://wiki.c2.com/?ArrangeActAssert) for writing tests, this bit we just did is the "Arrange" portion of the test._
+
+Next, let's call `plus1` (btw, this is the "Act" portion of Arrange-Act-Assert).
+
+```js
+// memoize.test.js
+
+test('should run the function if it has not been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	const result = memoizedFn(1);
+});
+```
+
+Finally, we can add our assertion.
+
+```js
+// memoize.test.js
+
+test('should run the function if it has not been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	const result = memoizedFn(1);
+
+	expect(result).toEqual(2);
+	expect(plus1).toHaveBeenCalledTimes(1);
+	expect(plus1).toHaveBeenCalledWith(1);
+});
+```
+
+In this test we want to assert three things about our `memoize` function:
+
+1. That `memoizedFn` returned the correct value (`.toEqual(2)` in our case).
+2. That `memoizedFn` was only called once (`.toHaveBeenCalledTimes(1)`). This will matter more in the next test.
+3. That `memoizedFn` actually was called with an argument of `1` (`.toHaveBeenCalledWith(1)`).
+
+For the second test, the first portion of the test looks exactly the same:
+
+```js
+// memoize.test.js
+
+test('should return a cached result if the function has been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+});
+```
+
+However, we'll call `memoizedFn` slightly differently. We're going to call it **three times** so that we can test that the cache is working. We'll call it first with `1`, then once with `2`, then again a third time with `1`.
+
+```js
+// memoize.test.js
+
+test('should return a cached result if the function has been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	memoizedFn(1);
+	memoizedFn(2);
+	const result = memoizedFn(1);
+});
+```
+
+Finally, we can write our assertions. We want to make sure that `plus1` **isn't called** the second time.
+
+```js
+// memoize.test.js
+
+test('should return a cached result if the function has been called with the same arguments', () => {
+	const plus1 = jest.fn((a) => a + 1);
+	const memoizedFn = memoize(plus1);
+
+	memoizedFn(1);
+	memoizedFn(2);
+	const result = memoizedFn(1);
+
+	expect(result).toEqual(2);
+	expect(plus1).toHaveBeenCalledTimes(2);
+});
+```
+
+For this test we only want to assert two things:
+
+1. That `memoizedFn` still returns the correct result (`.toEqual(2)`).
+2. That `plus1` was only called twice (once with `1`, once with `2`, the third time hit the cache).
+
+## Bonus BONUS: custom cache keys 🤯
+
+As a second bonus, let's add the ability to customize how the cache key is created.
+
+Currently, `memoize` just takes the first argument and uses that as a cache key. This is good enough for a lot of functions, but sometimes you need something a little more robust.
+
+We'll add an optional second argument to `memoize` called `getCacheKey`. As a default we're going to use the first argument, like we had before.
+
+```js
+const defaultGetCacheKey = (...args) => args[0];
+
+const memoize = (fn, getCacheKey = defaultGetCacheKey) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = args[0];
+
+		if (cache.has(cacheKey)) {
+			return cache.get(cacheKey);
+		}
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+Then, all that's left to do is swap `const cacheKey = args[0]` for our new function.
+
+```js
+const memoize = (fn, getCacheKey = (...args) => args[0]) => {
+	const cache = new Map();
+
+	return (...args) => {
+		const cacheKey = getCacheKey(...args);
+
+		if (cache.has(cacheKey)) {
+			return cache.get(cacheKey);
+		}
+
+		const result = fn(...args);
+		cache.set(cacheKey, result);
+		return result;
+	};
+};
+```
+
+Now, instead of only using the first argument to the memoized function as a cache key, we can use whatever we want!
+
+For example, instead of using the first argument to `add`, we can create a string containing both numbers.
+
+```js
+const add = (a, b) => a + b;
+const memoizedAdd = memoize(add, (a, b) => `${a}-${b}`);
+
+memoizedAdd(1, 3);
+memoizedAdd(1, 2);
+memoizedAdd(1, 4);
+
+// hits the cache for the key "1-2"
+memoizedAdd(1, 2);
+```
+
+Finally, let's add a test for this new functionality.
+
+```js
+// memoize.test.js
+
+test('should allow customization of the cache key', () => {
+	const add = jest.fn((a, b) => a + b);
+	const getCacheKey = (a, b) => `${a}-${b}`;
+	const memoized = memoize(add, getCacheKey);
+
+	memoized(1, 3);
+	memoized(1, 2);
+	memoized(1, 4);
+	const result = memoized(1, 2);
+
+	expect(result).toEqual(3);
+	expect(add).toHaveBeenCalledTimes(3);
+});
+```
+
+In this test we set up our memoized function and then run it three times with fresh input. In each of these first three calls, the _first argument is the same_. This way we can make sure that the cache key is actually changing.
+
+On the fourth time we run the memoized function with arguments that it has already received before.
+
+Lastly, we make our assertions—we'll assert that the fourth time returns the correct result (`3` and not the result of `memoized(1,3)`), and we'll assert that `add` only got called 3 times.
+
+---
+
+## Conclusion
+
+I hope that this was helpful! I know for myself, I learn a ton when I reimplement stuff that I commonly use from scratch.
+
+Feel free to reach out to me on [Twitter](https://twitter.com/benjamminj) or my [LinkedIn](https://www.linkedin.com/in/benjamin-d-johnson/) (reference this article so I know you're not a LinkedIn bot 😱 ).

--- a/packages/content/writing/writing-less.md
+++ b/packages/content/writing/writing-less.md
@@ -1,0 +1,21 @@
+---
+title: Writing less, and that's ok
+description: I'm learning to be easier on myself, slowly prune thoughts into posts, and write in smaller bursts.
+date: 2025-05-13
+tags:
+  - writing
+---
+
+I'm writing less these days.
+
+For the past few years, I've felt guilty about writing fewer blog posts. Earlier in my career, I published ~monthly; now it's more sporadic.
+
+Frankly, I have less gas in the tank to spend on writing. Back in 2020, I had a major burnout that left me unable to even write code for a while. Fast forward to today — I have 2 young children and less time overall to write blog posts.
+
+Plus, the things I want to write about are trickier: deep technical dives, philosophical musings about software development, and real-world stories. All of these require more effort than a simple tutorial. Pair that with my post-burnout energy and finishing posts feels more daunting.
+
+Finally, this website’s former design didn’t inspire me to write. I know "rewrite your portfolio" is a bit of an engineer trope, but this latest iteration makes me want to finish (or restart) some of those drafts.
+
+It’s tempting to compare yourself to other writers, especially prolific ones. But it's not healthy. We each have an amount we can give, and mine is smaller than it used to be.
+
+I'm writing less these days, and I'm ok with that. I'm learning to be easier on myself, slowly prune thoughts into posts, and write in smaller bursts.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       hast:
         specifier: ^1.0.0
         version: 1.0.0
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
       rehype-parse:
         specifier: ^9.0.1
         version: 9.0.1
@@ -159,6 +162,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-filter:
+        specifier: ^5.0.1
+        version: 5.0.1
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -6219,6 +6225,9 @@ packages:
   union@0.5.0:
     resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
     engines: {node: '>= 0.8.0'}
+
+  unist-util-filter@5.0.1:
+    resolution: {integrity: sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==}
 
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
@@ -13627,6 +13636,12 @@ snapshots:
   union@0.5.0:
     dependencies:
       qs: 6.15.2
+
+  unist-util-filter@5.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-is@4.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,15 +108,63 @@ importers:
 
   apps/website-sv:
     dependencies:
+      '@benjamminj/content':
+        specifier: workspace:*
+        version: link:../../packages/content
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      front-matter:
+        specifier: ^4.0.2
+        version: 4.0.2
+      glob:
+        specifier: ^11.1.0
+        version: 11.1.0
+      hast:
+        specifier: ^1.0.0
+        version: 1.0.0
+      rehype-parse:
+        specifier: ^9.0.1
+        version: 9.0.1
+      rehype-pretty-code:
+        specifier: ^0.14.1
+        version: 0.14.1(shiki@3.19.0)
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.2
+        version: 11.1.2
+      shiki:
+        specifier: ^3.19.0
+        version: 3.19.0
       tailwind-merge:
         specifier: ^1.14.0
         version: 1.14.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
@@ -163,6 +211,8 @@ importers:
       vitest-browser-svelte:
         specifier: ^2.1.0
         version: 2.1.1(svelte@5.56.0)(vitest@4.1.7)
+
+  packages/content: {}
 
 packages:
 
@@ -1049,14 +1099,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3863,6 +3905,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  hast@1.0.0:
+    resolution: {integrity: sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==}
+    deprecated: Renamed to rehype
+
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
@@ -4700,10 +4746,6 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -5419,6 +5461,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -7561,12 +7606,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -10714,7 +10753,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.2.5
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -10849,6 +10888,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hast@1.0.0: {}
 
   hastscript@9.0.1:
     dependencies:
@@ -11877,10 +11918,6 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.1.1:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -12768,6 +12805,12 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
some notes

- for now just copied all content into the sveltekit version for ease of development. will package it out later. majority of the diff is from there.
- none of the other pages migrated yet, this is just the homepage + markdown renderer.